### PR TITLE
fix: settings always showing NTP sync failed status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+* **Settings diagnostics always showed `[02] NTP sync failed`** — Every force-sync action (long-press, Settings › Sync tap, Dashboard click) was incorrectly resetting `rtcWakeupCount` to 0, causing the NTP client to run on every user-triggered sync instead of only once every 48 wakeups (~24 hours). If the NTP server was transiently unreachable right after WiFi reconnected, `kErrNtpFail` was written to RTC memory and shown persistently. Fix: removed `rtcWakeupCount = 0` from all three force-sync code paths — force-sync triggers a weather refresh only; the NTP cadence is now independent.
+* **NTPManager: stale SNTP state on re-entry** — `esp_sntp_stop()` is now called once before the retry loop in `NTPManager::sync()` to guarantee a clean SNTP daemon state at the start of each sync attempt. Previously only inter-attempt stops were issued; this ensures no stale status from an unexpected prior initialisation path can cause an immediate false-COMPLETED or false-IN_PROGRESS result.
+
+---
+
 ## [3.0.0] - 2026-03-14
 
 ### Added

--- a/lib/App/AppController.cpp
+++ b/lib/App/AppController.cpp
@@ -256,7 +256,6 @@ void AppController::_runInteractiveSession(const String& locationStr) {
         if (input.checkLongPress()) {
             ESP_LOGI(TAG, "G38 long-press → force sync");
             disp.showMessage("Syncing...", "Fetching fresh weather data");
-            rtcWakeupCount = 0;
             rtcCachedWeather.valid = false;
             _enterDeepSleepForImmediateWakeup();
         }
@@ -295,7 +294,6 @@ void AppController::_runInteractiveSession(const String& locationStr) {
                 if (col == 0) {
                     ESP_LOGI(TAG, "Force Sync Triggered via tap");
                     disp.showMessage("Syncing...", "Fetching fresh weather data");
-                    rtcWakeupCount = 0;
                     rtcCachedWeather.valid = false;
                     _enterDeepSleepForImmediateWakeup();
                 } else if (col == 1) {
@@ -353,7 +351,6 @@ void AppController::_runInteractiveSession(const String& locationStr) {
                 // Dashboard: click = force sync (same as long-press shortcut)
                 ESP_LOGI(TAG, "G38 on Dashboard → force sync");
                 disp.showMessage("Syncing...", "Fetching fresh weather data");
-                rtcWakeupCount = 0;
                 rtcCachedWeather.valid = false;
                 _enterDeepSleepForImmediateWakeup();
             } else if (disp.getActivePage() == Page::Forecast) {

--- a/lib/Network/NTPManager.cpp
+++ b/lib/Network/NTPManager.cpp
@@ -18,6 +18,9 @@ bool NTPManager::sync(const String& ntpServer, const String& timezone,
 
     _ntpFailed = false;
 
+    // Stop any stale SNTP daemon before starting fresh — harmless if not running.
+    esp_sntp_stop();
+
     for (int attempt = 1; attempt <= maxRetries; attempt++) {
         // Provide the timezone string (POSIX format) and the NTP server.
         configTzTime(timezone.c_str(), ntpServer.c_str());


### PR DESCRIPTION
- Remove rtcWakeupCount = 0 from all three force-sync paths (long-press, Settings tap, Dashboard click). Resetting the counter caused NTP to run on every user-triggered sync instead of the intended 48-wakeup cadence; a transient DNS/NTP timeout then wrote kErrNtpFail into RTC memory where it persisted indefinitely on the Settings diagnostics page.
- Add esp_sntp_stop() before the retry loop in NTPManager::sync() to guarantee a clean SNTP daemon state at the start of each sync call, preventing stale status from a prior initialisation path surfacing as an immediate false result.