### PR TITLE
feat: adaptive sleep, pollen index, wind gusts, UV recommendation, rain/precip badges, barometric trend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+* **Adaptive sleep interval** — `enterDeepSleep()` scans the cached hourly forecast: if any of the next 3 hours shows a precipitation-chance increase of more than 20 percentage points over the current hour, the sleep interval is automatically shortened to 10 minutes. No additional API call — uses already-cached `hourly[]` data.
+* **Pollen / Allergen Index widget** — The existing Open-Meteo air-quality fetch is extended with `&hourly=grass_pollen,birch_pollen,weed_pollen`. The peak value over the next 8 hours is stored in `WeatherData::pollenGrass/Birch/Weed`. The Dashboard details grid shows a `"Pollen: X (type)"` row where type is the dominant species at peak.
+* **Precipitation type badges on Forecast cards** — Each 10-day card maps its condition text to a distinct inverted mini-badge: `Rain`, `Snow`, `Ice` (freezing rain / sleet / ice pellets), `Storm` (thunderstorm), or `Hail`. Badge is omitted for clear/cloudy days. No additional API call.
+* **Wind gust display** — `wind_gusts_10m` is appended to the existing Open-Meteo hourly parameter string. `HourlyForecast::windGustKph` and `WeatherData::windGustKph` (current hour) are populated. The Dashboard details grid shows `"Gusts: XX km/h"` on the new row 4.
+* **UV recommendation text** — The UV index row in the Dashboard details grid now appends an inline risk label: `UV Index: X - Low / Moderate / High / Very High / Extreme`. Zero additional complexity; derived from the already-fetched `data.uvIndex`.
+* **Rain-before-commute badge** — On each render of the Dashboard, if any of the next 3 hourly entries has `precipChance > 60%` an inverted `RAIN` badge is drawn in the top-left corner of the clock header.
+* **Barometric trend arrow** — `HourlyForecast::pressureHpa` and `WeatherData::pressureHpa` are populated from `surface_pressure` (appended to the existing Open-Meteo hourly request). A 3-entry rolling ring (`rtcPressureRing[]`) in RTC memory tracks readings across wakeup cycles. `WeatherData::pressureTrend` is set by `AppController` after each successful fetch (trend = newest – oldest reading in hPa). The Dashboard row 4 right column shows `"Pres: Rising / Steady / Falling"`.
+
 ### Fixed
 
 * **Settings diagnostics always showed `[02] NTP sync failed`** — Every force-sync action (long-press, Settings › Sync tap, Dashboard click) was incorrectly resetting `rtcWakeupCount` to 0, causing the NTP client to run on every user-triggered sync instead of only once every 48 wakeups (~24 hours). If the NTP server was transiently unreachable right after WiFi reconnected, `kErrNtpFail` was written to RTC memory and shown persistently. Fix: removed `rtcWakeupCount = 0` from all three force-sync code paths — force-sync triggers a weather refresh only; the NTP cadence is now independent.

--- a/docs/features.md
+++ b/docs/features.md
@@ -5,8 +5,8 @@ This document outlines the core user-facing functionalities implemented in the M
 ## 🌤️ Weather Forecasting Engine
 
 * **10-Day Deep Lookahead**: The device specifically overrides standard Google Weather API pagination caps (which default to 5 days) by enforcing `pageSize=10`. This allows the application to cleanly parse 10 contiguous days of highs, lows, precipitation chances, and prevailing condition states in a single JSON block.
-* **Live Ambient Conditions**: Fetches real-time localised temperature, relative humidity, dynamic "feels like" temperature, wind speed with 8-point compass direction, UV index, visibility, and cloud cover.
-* **Supplemental Environmental APIs**: While Google Weather drives the core forecast, the engine initiates synchronous unauthenticated Open-Meteo HTTP fetches to derive real-time US EPA Air Quality Index (AQI) values and track daily ephemeris (sunrise and sunset) timestamps without incurring API-key bottlenecks.
+* **Live Ambient Conditions**: Fetches real-time localised temperature, relative humidity, dynamic "feels like" temperature, wind speed with 8-point compass direction, wind gusts, UV index with risk recommendation, visibility, and cloud cover.
+* **Supplemental Environmental APIs**: While Google Weather drives the core forecast, the engine initiates synchronous unauthenticated Open-Meteo HTTP fetches to derive real-time US EPA Air Quality Index (AQI) values, track daily ephemeris (sunrise and sunset) timestamps, fetch pollen counts (grass, birch, weed), and obtain surface pressure for barometric trend analysis — all without incurring API-key bottlenecks.
 * **Dynamic Screen Formatting**: Given that city names range from `"Rome"` to `"Llanfairpwllgwyngyll"`, the application engine natively concatenates the optional State parameter and uses hardware-accelerated bounding boxes (`drawCentreString`) to ensure the locale is perfectly horizontally aligned regardless of string length.
 
 ## 📱 Multi-Page E-Ink UI
@@ -17,10 +17,11 @@ Displays the current conditions dashboard:
 
 * Large time and date header with full weekday, month, and year.
 * Hero section: vector weather icon alongside temperature.
-* **Details grid** (3 rows): Feels Like / Wind speed + compass bearing; Humidity / Cloud cover; UV index / Visibility.
+* **Details grid** (4 rows): Feels Like / Wind speed + compass bearing; Humidity / Cloud cover; UV index with inline risk label / Visibility; Wind gusts + barometric trend / Peak pollen species + count.
 * **Wind rose compass**: 8-point compass visualization showing prevailing wind direction with speed indicator.
 * **Moon Phase Widget**: Display fractional moon phase derived from unixtime using shading logic.
 * **Environmental dials**: AQI half-arc gauge with needle, and astronomical Sun Arc showing the sun's position across the day with flanking sunrise and sunset times.
+* **Rain-before-commute badge**: An inverted `RAIN` badge appears in the top-left corner of the clock header when any of the next 3 hourly forecast entries shows precipitation chance > 60%.
 * **Tomorrow preview**: centred card with weather icon, condition text, high/low temperatures, and precipitation chance.
 
 ### Hourly Forecast Page (New)
@@ -35,7 +36,7 @@ Displays the current conditions dashboard:
 
 * **Temperature band sparkline**: dual-line chart plotting daily highs (thick) and lows (thin) across all 10 days with Y-axis, Hi/Lo legend, and degree labels.
 * **Precipitation bar chart**: vertical bar chart showing rain probability (0–100 %) per day, aligned to the same horizontal grid as the temperature chart.
-* **Scrollable forecast cards** (3 visible at a time, swipe to scroll): real weekday name from timestamp (`Mon 12`), vector weather icon, condition text, H/L temperatures, temperature range bar contextualised against the full 10-day span, and precipitation chance.
+* **Scrollable forecast cards** (3 visible at a time, swipe to scroll): real weekday name from timestamp (`Mon 12`), vector weather icon, condition text, **precipitation type badge** (Rain / Snow / Ice / Storm / Hail — derived from condition text, no extra API call), H/L temperatures, temperature range bar contextualised against the full 10-day span, and precipitation chance.
 
 ### Settings & Diagnostics Page
 
@@ -45,6 +46,7 @@ Displays the current conditions dashboard:
 ## ⚙️ Seamless Device Management
 
 * **Configurable sync interval**: The deep-sleep timer duration is configurable via the AP provisioning portal; the hardcoded 30-minute default can be raised or lowered at runtime.
+* **Adaptive sleep interval**: If any of the next 3 hourly forecast entries shows a precipitation-chance increase of more than 20 percentage points over the current hour, the sleep interval is automatically shortened to 10 minutes — no additional API call required.
 * **Battery-adaptive sync rate**: If the battery voltage drops below 40% (≈3650 mV), the synchronization interval automatically doubles to preserve power without user intervention.
 * **Double-click webhook**: A physical double-tap of G38 fires an HTTP GET to a user-configured webhook URL and displays a brief confirmation on screen. Configurable in the provisioning portal.
 * **Multi-Network WiFi Roaming**: Up to 5 SSID/password pairs can be stored in NVS. On each wake the device scans for available access points, ranks matching SSIDs by received signal strength (RSSI), and connects to the strongest available network automatically. A fast-connect cache (BSSID + channel) in `RTC_DATA_ATTR` is keyed to the last successfully connected SSID; if it is still in range it is tried first to skip the channel scan.

--- a/docs/ui-mockups.md
+++ b/docs/ui-mockups.md
@@ -61,21 +61,23 @@ Y ≈  ┌───────────────────────�
      │                                                      │
  390 │  Feels: 26.1°C          │  NW 15 km/h  [wind rose]   │ ← details row 1 (split X=270); compass prefix
  430 │  Humidity: 62%          │  Clouds: 45%               │ ← details row 2 (full label names)
- 470 │  UV Index: 4            │  Visibility: 12 km         │ ← details row 3  FreeSans12pt
+ 470 │  UV Index: 4 - Moderate │  Visibility: 12 km         │ ← details row 3; UV rec appended inline
+ 510 │  Gusts: 24 km/h              │  Pres: Rising        │ ← row 4a: gusts (left) / pressure trend (right)
+ 550 │  Pollen: 12 (Grass)                                  │ ← row 4b: pollen (full left)
      │                                                      │
      │  ┌─────────────┐        │  ┌──────────────────┐      │
      │  │   ╱── arc   │        │  │   dome arc  ───  │      │
- 570 │  │   /         │  AQI   │  │   ──── ☀ ──      │ Sun  │ ← AQI gauge cx=135 / Sun arc cx=405
+ 620 │  │   /         │  AQI   │  │   ──── ☀ ──      │ Sun  │ ← AQI gauge cx=135 / Sun arc cx=405
      │  │  ╱  needle  │        │  │                  │      │   r=45 half-arc for both widgets
      │  │    ●   48   │        │  │                  │      │
- 608 │  │    AQI      │ 6:42      │        19:53     │      │ ← sunrise MR_DATUM / sunset ML_DATUM
-     │  └─────────────┘           └──────────────────┘      │   flanking sunCX=405, Y=608
- 635 ├──────────────────────────────────────────────────────┤ ← rule
- 655 │                      Tomorrow                        │ ← FreeSans18pt, TC_DATUM
+ 658 │  │    AQI      │ 6:42      │        19:53     │      │ ← sunrise MR_DATUM / sunset ML_DATUM
+     │  └─────────────┘           └──────────────────┘      │   flanking sunCX=405, Y=658
+ 685 ├──────────────────────────────────────────────────────┤ ← rule
+ 705 │                      Tomorrow                        │ ← FreeSans18pt, TC_DATUM
      │                                                      │
- 730 │                  [weather icon]                       │ ← cx=270, cy=730, r=20
- 800 │                   Mostly Cloudy                       │ ← FreeSans18pt, TC_DATUM (below icon bottom 786)
- 835 │         H: 30°C   L: 21°C   Precip: 30%               │ ← FreeSans12pt, TC_DATUM
+ 780 │                  [weather icon]                       │ ← cx=270, cy=780, r=20
+ 850 │                   Mostly Cloudy                       │ ← FreeSans18pt, TC_DATUM (below icon bottom 836)
+ 885 │         H: 30°C   L: 21°C   Precip: 30%               │ ← FreeSans12pt, TC_DATUM
      │                                                      │
  855 ████████████ ⚠  Tornado Watch in Effect ████████████████ ← inverted 32px strip, white text
  887 │                                                      │   FreeSans9pt, MC_DATUM; truncated @52+…
@@ -90,6 +92,7 @@ Y ≈  ┌───────────────────────�
 |-------:|-------:|---------|--------------|
 | 15 | 485 | Battery: 40×20 outer rect + 4×10 nub + fill | Inline `%` MR_DATUM, X=480 |
 | 20 | kWidth/2 | Time `"2:51 PM"` | FreeSansBold24pt ×2, TC_DATUM |
+| 20 | 8 | `"RAIN"` badge (inverted) | Default font ×1; only when any of `hourly[0..2].precipChance > 60` |
 | 22 | kWidth−44 | `"NTP!"` badge | Default font ×1; only when `_ntpFailed` |
 | 110 | kWidth/2 | City / State string | FreeSans24pt ×1 |
 | 160 | kWidth/2 | Date `"Sunday, March 09 2026"` | FreeSans18pt |
@@ -99,15 +102,18 @@ Y ≈  ┌───────────────────────�
 | 330 | kWidth/2 | Condition string | FreeSans24pt |
 | 390 | 40 / 290 | Feels Like / Wind + direction (8-point compass) | FreeSans12pt |
 | 430 | 40 / 290 | Humidity / Cloud cover | FreeSans12pt |
-| 470 | 40 / 290 | UV index / Visibility | FreeSans12pt |
-| 570 | cx=135 | AQI half-arc gauge (r=45) + filled-triangle needle + pivot (r=6) | FreeSansBold9pt labels |
-| 570 | cx=405 | Sun arc dome (r=45, r−4 thick) + sun dot (daytime) or crescent (night) | FreeSansBold9pt `"Sun"` |
-| 608 | sunCX−48 / sunCX+48 | Sunrise / sunset times | FreeSansBold9pt, MR / ML datum |
-| 635 | 20–520 | Horizontal rule | 1 px |
-| 655 | kWidth/2 | `"Tomorrow"` label | FreeSans18pt, TC_DATUM |
-| 730 | kWidth/2 | Tomorrow icon (r=20) | Condition-matched vector |
-| 800 | kWidth/2 | Tomorrow condition | FreeSans18pt, TC_DATUM; shifted below icon bottom (730+56+14=800) |
-| 835 | kWidth/2 | Tomorrow `"H: xx°C   L: xx°C   Precip: xx%"` | FreeSans12pt, TC_DATUM |
+| 470 | 40 / 290 | UV index + inline rec / Visibility | FreeSans12pt; rec appended as `"- Low/Moderate/High/Very High/Extreme"` |
+| 510 | 40 / 290 | Wind gusts (left) / Pressure trend (right) | FreeSans12pt; left: `"Gusts: XX km/h"`; right: `"Pres: Rising/Steady/Falling"` |
+| 550 | 40 | Peak pollen | FreeSans12pt; `"Pollen: X (Grass/Birch/Weed)"` or `"Pollen: --"` |
+| 550 | 40 | Peak pollen | FreeSans12pt; `"Pollen: X (Grass/Birch/Weed)"` or `"Pollen: --"` |
+| 620 | cx=135 | AQI half-arc gauge (r=45) + filled-triangle needle + pivot (r=6) | FreeSansBold9pt labels |
+| 620 | cx=405 | Sun arc dome (r=45, r−4 thick) + sun dot (daytime) or crescent (night) | FreeSansBold9pt `"Sun"` |
+| 658 | sunCX−48 / sunCX+48 | Sunrise / sunset times | FreeSansBold9pt, MR / ML datum |
+| 685 | 20–520 | Horizontal rule | 1 px |
+| 705 | kWidth/2 | `"Tomorrow"` label | FreeSans18pt, TC_DATUM |
+| 780 | kWidth/2 | Tomorrow icon (r=20) | Condition-matched vector |
+| 850 | kWidth/2 | Tomorrow condition | FreeSans18pt, TC_DATUM; shifted below icon bottom (780+56+14=850) |
+| 885 | kWidth/2 | Tomorrow `"H: xx°C   L: xx°C   Precip: xx%"` | FreeSans12pt, TC_DATUM |
 | 855–887 | 0–540 | Alert banner — inverted black rect + white text | FreeSans9pt, MC_DATUM; shown when `data.hasAlert` |
 | 940 | 246 / 270 / 294 / 318 | Pagination dots (r=6 filled / r=5+4 hollow ring) | Active = filled; active page name at Y=930 BC_DATUM |
 | 955 | kWidth−15 | `"Updated: HH:MM"` | FreeSansBold9pt, BR_DATUM |

--- a/lib/App/AppController.cpp
+++ b/lib/App/AppController.cpp
@@ -32,6 +32,8 @@ RTC_DATA_ATTR int         rtcSettingsCursor = 0;
 RTC_DATA_ATTR char        rtcLastIP[16] = {};
 RTC_DATA_ATTR uint8_t     rtcLastError = 0; ///< AppError code from most recent fetch cycle
 RTC_DATA_ATTR uint8_t     rtcGhostCount = 0; ///< Full-quality redraw counter for ghost cleanup
+RTC_DATA_ATTR float       rtcPressureRing[3] = {}; ///< Rolling surface-pressure readings (hPa) for trend computation
+RTC_DATA_ATTR uint8_t     rtcPressureCount = 0;    ///< Number of valid entries in rtcPressureRing (clamped to 3)
 
 // ── Configuration ────────────────────────────────────────────────────────────
 static constexpr uint64_t kSleepDurationUs     = 30ULL * 60ULL * 1000000ULL; // 30 minutes
@@ -143,6 +145,19 @@ void AppController::begin() {
                 rtcCachedWeather = data; // persist to RTC
                 rtcLastError = NTPManager::getInstance().isNtpFailed() ? kErrNtpFail : kErrNone;
                 disp.updateLoadingStep(3); // 100% bar — no-ops if no loading screen active
+
+                // ── Rolling pressure ring for barometric trend ────────────────
+                // Shift ring left and insert newest reading; trend = newest - oldest.
+                // Three readings at the default 30-min sync cadence ≈ 1-hour window.
+                if (rtcCachedWeather.pressureHpa > 0.0f) {
+                    rtcPressureRing[0] = rtcPressureRing[1];
+                    rtcPressureRing[1] = rtcPressureRing[2];
+                    rtcPressureRing[2] = rtcCachedWeather.pressureHpa;
+                    if (rtcPressureCount < 3) rtcPressureCount++;
+                    if (rtcPressureCount >= 3) {
+                        rtcCachedWeather.pressureTrend = rtcPressureRing[2] - rtcPressureRing[0];
+                    }
+                }
             } else {
                 rtcLastError = kErrWeatherFail;
             }
@@ -424,6 +439,21 @@ void AppController::enterDeepSleep() {
     if (batMv > 0 && batMv < 3650) {
         ESP_LOGI(TAG, "Battery voltage low (%d mV), doubling sync interval to save power.", batMv);
         syncIntevalM *= 2;
+    }
+
+    // Adaptive sleep: shorten to 10 min when precipitation is rapidly increasing.
+    // If any of the next 3 hourly entries has a precipChance > 20% higher than the
+    // current hour, the device will sync more often to catch fast-developing rain.
+    if (rtcCachedWeather.valid && rtcCachedWeather.hourlyCount >= 2) {
+        int basePrecip = rtcCachedWeather.hourly[0].precipChance;
+        for (int i = 1; i < 3 && i < rtcCachedWeather.hourlyCount; i++) {
+            if (rtcCachedWeather.hourly[i].precipChance - basePrecip > 20) {
+                ESP_LOGI(TAG, "Rapid precip increase (+%d%% in %dh) — shortening sync to 10 min",
+                         rtcCachedWeather.hourly[i].precipChance - basePrecip, i);
+                syncIntevalM = std::min((uint64_t)syncIntevalM, (uint64_t)10);
+                break;
+            }
+        }
     }
 
     uint64_t sleepUs = syncIntevalM * 60ULL * 1000000ULL;

--- a/lib/Display/DisplayManager.cpp
+++ b/lib/Display/DisplayManager.cpp
@@ -340,6 +340,23 @@ void DisplayManager::drawPageDashboard(const WeatherData& data,
         _canvas.setTextSize(2);
     }
 
+    // Rain-before-commute badge — shown when precipChance >60% within the next 3 forecast hours.
+    // Drawn as an inverted badge in the top-left corner (leaves NTP! spot free on right).
+    if (data.valid && data.hourlyCount >= 1) {
+        bool rainSoon = false;
+        for (int i = 0; i < 3 && i < data.hourlyCount; i++) {
+            if (data.hourly[i].precipChance > 60) { rainSoon = true; break; }
+        }
+        if (rainSoon) {
+            _canvas.setFont(nullptr);
+            _canvas.setTextSize(1);
+            _canvas.fillRect(8, 18, 50, 14, TFT_BLACK);
+            _canvas.setTextColor(TFT_WHITE);
+            _canvas.drawString("RAIN", 11, 20);
+            _canvas.setTextColor(TFT_BLACK);
+        }
+    }
+
     // ── Main Content ──────────────────────────────────────────────────────────
     String dispCity = city;
     if (dispCity.isEmpty()) dispCity = "Unknown";
@@ -400,13 +417,45 @@ void DisplayManager::drawPageDashboard(const WeatherData& data,
     _canvas.drawString(buf2, kWidth/2 + 20, 430);
 
     snprintf(buf1, sizeof(buf1), "UV Index: %d", data.uvIndex);
+    // UV recommendation appended inline — zero additional API data required.
+    { static const char* kUVRec[] = { "Low", "Low", "Low", "Moderate", "Moderate",
+                                      "High", "High", "Very High", "Very High",
+                                      "Extreme", "Extreme", "Extreme" };
+      int uvClamped = std::min(data.uvIndex, 11);
+      strncat(buf1, " - ", sizeof(buf1) - strlen(buf1) - 1);
+      strncat(buf1, kUVRec[uvClamped], sizeof(buf1) - strlen(buf1) - 1); }
     _canvas.drawString(buf1, 40, 470);
     snprintf(buf2, sizeof(buf2), "Visibility: %.0f km", data.visibilityKm);
     _canvas.drawString(buf2, kWidth/2 + 20, 470);
 
+    // ── Row 4a (Y=510): Wind gusts (left) | Pressure trend (right) ──────────
+    if (data.windGustKph > 0.5f)
+        snprintf(buf1, sizeof(buf1), "Gusts: %.0f km/h", data.windGustKph);
+    else
+        snprintf(buf1, sizeof(buf1), "Gusts: --");
+    _canvas.drawString(buf1, 40, 510);
+
+    { const char* trendStr;
+      if (data.pressureTrend > 1.0f)       trendStr = "Pres: Rising";
+      else if (data.pressureTrend < -1.0f) trendStr = "Pres: Falling";
+      else if (data.pressureHpa > 0.0f)    trendStr = "Pres: Steady";
+      else                                  trendStr = "";
+      if (trendStr[0]) _canvas.drawString(trendStr, kWidth/2 + 20, 510); }
+
+    // ── Row 4b (Y=550): Pollen peak — dominant type shown ────────────────────
+    { int peakPollen = std::max({data.pollenGrass, data.pollenBirch, data.pollenWeed});
+      if (peakPollen > 0) {
+          const char* pollenType = (data.pollenGrass >= data.pollenBirch && data.pollenGrass >= data.pollenWeed)
+              ? "Grass" : (data.pollenBirch >= data.pollenWeed ? "Birch" : "Weed");
+          snprintf(buf2, sizeof(buf2), "Pollen: %d (%s)", peakPollen, pollenType);
+      } else {
+          snprintf(buf2, sizeof(buf2), "Pollen: --");
+      }
+      _canvas.drawString(buf2, 40, 550); }
+
     // ── Environmental Dials ───────────────────────────────────────────────────
-    _drawAQIGauge(data.aqi, 570);
-    _drawSunArc(time(nullptr), data.sunriseTime, data.sunsetTime, 570);
+    _drawAQIGauge(data.aqi, 620);
+    _drawSunArc(time(nullptr), data.sunriseTime, data.sunsetTime, 620);
 
     // Sunrise / sunset times flanking the sun arc label
     if (data.sunriseTime > 0 && data.sunsetTime > 0) {
@@ -420,9 +469,9 @@ void DisplayManager::drawPageDashboard(const WeatherData& data,
         _canvas.setFont(&fonts::FreeSansBold9pt7b);
         _canvas.setTextSize(1);
         _canvas.setTextDatum(MR_DATUM);
-        _canvas.drawString(srBuf, sunCX - 48, 608);
+        _canvas.drawString(srBuf, sunCX - 48, 658);
         _canvas.setTextDatum(ML_DATUM);
-        _canvas.drawString(ssBuf, sunCX + 48, 608);
+        _canvas.drawString(ssBuf, sunCX + 48, 658);
         _canvas.setTextDatum(TL_DATUM);
     }
 
@@ -430,7 +479,7 @@ void DisplayManager::drawPageDashboard(const WeatherData& data,
     {
         int moonCX = (kWidth * 5) / 6;
         int moonR  = 38;
-        int moonCY = 555; // shifted up so label fits below without overlap
+        int moonCY = 605; // shifted up so label fits below without overlap
         _drawMoonPhase(time(nullptr), moonCX, moonCY, moonR);
         _canvas.setFont(&fonts::FreeSansBold9pt7b);
         _canvas.setTextSize(1);
@@ -440,7 +489,7 @@ void DisplayManager::drawPageDashboard(const WeatherData& data,
     }
 
     // Divider
-    _canvas.drawFastHLine(20, 635, kWidth - 40, TFT_BLACK);
+    _canvas.drawFastHLine(20, 685, kWidth - 40, TFT_BLACK);
 
     // ── Tomorrow Preview ──────────────────────────────────────────────────────
     if (data.forecastDays > 1) {
@@ -448,19 +497,19 @@ void DisplayManager::drawPageDashboard(const WeatherData& data,
         _canvas.setTextDatum(TC_DATUM);
 
         _canvas.setFont(&fonts::FreeSans18pt7b);
-        _canvas.drawString("Tomorrow", kWidth / 2, 655);
+        _canvas.drawString("Tomorrow", kWidth / 2, 705);
 
-        _drawWeatherIcon(tmr.condition, kWidth / 2, 730, 56);
+        _drawWeatherIcon(tmr.condition, kWidth / 2, 780, 56);
 
-        // #4: Move text below icon bottom (730+56=786) to avoid overlap
+        // Text below icon bottom (780+56=836) to avoid overlap
         _canvas.setFont(&fonts::FreeSans18pt7b);
-        _canvas.drawString(tmr.condition, kWidth / 2, 800);
+        _canvas.drawString(tmr.condition, kWidth / 2, 850);
 
         _canvas.setFont(&fonts::FreeSans12pt7b);
         char tBuf[48];
         snprintf(tBuf, sizeof(tBuf), "H: %.0f C   L: %.0f C   Precip: %d%%",
                  tmr.maxTempC, tmr.minTempC, tmr.precipChance);
-        _canvas.drawString(tBuf, kWidth / 2, 835);
+        _canvas.drawString(tBuf, kWidth / 2, 885);
 
         _canvas.setTextDatum(TL_DATUM);
     }
@@ -533,6 +582,36 @@ void DisplayManager::drawPageForecast(const WeatherData& data, int forecastOffse
             String cond = f.condition;
             if (cond.length() > 12) cond = cond.substring(0, 10) + "..";
             _canvas.drawString(cond, cx, 522);
+
+            // ── Precipitation type badge ──────────────────────────────────────
+            // Map condition text to a distinct precip-type label so users can
+            // distinguish rain / snow / ice / thunderstorm on the forecast cards
+            // without relying on icon shape alone.  No additional API call needed.
+            { const char* precipBadge = nullptr;
+              String condLower = f.condition;
+              condLower.toLowerCase();
+              if (condLower.indexOf("thunder") >= 0 || condLower.indexOf("storm") >= 0)
+                  precipBadge = "Storm";
+              else if (condLower.indexOf("hail") >= 0)
+                  precipBadge = "Hail";
+              else if (condLower.indexOf("freezing") >= 0 || condLower.indexOf("sleet") >= 0
+                       || condLower.indexOf("ice") >= 0 || condLower.indexOf("pellet") >= 0)
+                  precipBadge = "Ice";
+              else if (condLower.indexOf("snow") >= 0 || condLower.indexOf("blizzard") >= 0)
+                  precipBadge = "Snow";
+              else if (condLower.indexOf("rain") >= 0 || condLower.indexOf("shower") >= 0
+                       || condLower.indexOf("drizzle") >= 0)
+                  precipBadge = "Rain";
+              if (precipBadge) {
+                  // Inverted small badge between condition line and H/L line
+                  int badgeX = cx - 18;
+                  int badgeY = 540;
+                  _canvas.fillRect(badgeX, badgeY, 36, 13, TFT_BLACK);
+                  _canvas.setTextColor(TFT_WHITE);
+                  _canvas.drawString(precipBadge, cx, badgeY + 1);
+                  _canvas.setTextColor(TFT_BLACK);
+              }
+            }
 
             // ── H / L text ────────────────────────────────────────────────────
             char tempBuf[24];

--- a/lib/Network/WeatherService.cpp
+++ b/lib/Network/WeatherService.cpp
@@ -145,8 +145,12 @@ WeatherData WeatherService::fetch(const String& lat, const String& lon,
     }
     http.end();
 
-    // --- 3. Fetch Supplemental AQI ---
-    String aqiUrl = "https://air-quality-api.open-meteo.com/v1/air-quality?latitude=" + lat + "&longitude=" + lon + "&current=us_aqi";
+    // --- 3. Fetch Supplemental AQI + Pollen ---
+    // Append hourly pollen fields to the same air-quality request at no extra cost.
+    String aqiUrl = "https://air-quality-api.open-meteo.com/v1/air-quality?latitude=" + lat + "&longitude=" + lon
+        + "&current=us_aqi"
+        + "&hourly=grass_pollen,birch_pollen,weed_pollen"
+        + "&timeformat=unixtime&timezone=auto&forecast_days=1";
     http.begin(client, aqiUrl);
     code = http.GET();
     if (code == HTTP_CODE_OK) {
@@ -154,6 +158,27 @@ WeatherData WeatherService::fetch(const String& lat, const String& lon,
         JsonDocument aqiDoc;
         if (!deserializeJson(aqiDoc, payload)) {
             data.aqi = aqiDoc["current"]["us_aqi"].as<int>();
+
+            // Parse hourly pollen — take the peak value over the next 8 hours from now.
+            JsonArray pollenTimes = aqiDoc["hourly"]["time"].as<JsonArray>();
+            JsonArray pollenGrassArr = aqiDoc["hourly"]["grass_pollen"].as<JsonArray>();
+            JsonArray pollenBirchArr = aqiDoc["hourly"]["birch_pollen"].as<JsonArray>();
+            JsonArray pollenWeedArr  = aqiDoc["hourly"]["weed_pollen"].as<JsonArray>();
+            time_t currentTime = time(nullptr);
+            int peakGrass = 0, peakBirch = 0, peakWeed = 0;
+            int hoursScanned = 0;
+            for (size_t pidx = 0; pidx < pollenTimes.size() && hoursScanned < 8; pidx++) {
+                time_t pt = pollenTimes[pidx].as<time_t>();
+                if (pt >= currentTime - 1800) { // from current hour onwards
+                    peakGrass = std::max(peakGrass, pollenGrassArr[pidx].as<int>());
+                    peakBirch = std::max(peakBirch, pollenBirchArr[pidx].as<int>());
+                    peakWeed  = std::max(peakWeed,  pollenWeedArr[pidx].as<int>());
+                    hoursScanned++;
+                }
+            }
+            data.pollenGrass = peakGrass;
+            data.pollenBirch = peakBirch;
+            data.pollenWeed  = peakWeed;
         } else {
             ESP_LOGW(TAG, "Failed to parse AQI JSON");
         }
@@ -163,8 +188,10 @@ WeatherData WeatherService::fetch(const String& lat, const String& lon,
     http.end();
 
     // --- 4. Fetch Supplemental Sun Times & Hourly Forecast ---
+    // wind_gusts_10m and surface_pressure are appended at no additional API cost.
     String sunUrl = "https://api.open-meteo.com/v1/forecast?latitude=" + lat + "&longitude=" + lon 
-        + "&daily=sunrise,sunset&hourly=temperature_2m,weather_code,precipitation_probability,wind_speed_10m"
+        + "&daily=sunrise,sunset"
+        + "&hourly=temperature_2m,weather_code,precipitation_probability,wind_speed_10m,wind_gusts_10m,surface_pressure"
         + "&timeformat=unixtime&timezone=auto&forecast_days=2";
     http.begin(client, sunUrl);
     code = http.GET();
@@ -175,11 +202,13 @@ WeatherData WeatherService::fetch(const String& lat, const String& lon,
             data.sunriseTime = sunDoc["daily"]["sunrise"][0].as<time_t>();
             data.sunsetTime  = sunDoc["daily"]["sunset"][0].as<time_t>();
 
-            JsonArray hourlyTimes = sunDoc["hourly"]["time"].as<JsonArray>();
-            JsonArray hourlyTemps = sunDoc["hourly"]["temperature_2m"].as<JsonArray>();
+            JsonArray hourlyTimes    = sunDoc["hourly"]["time"].as<JsonArray>();
+            JsonArray hourlyTemps    = sunDoc["hourly"]["temperature_2m"].as<JsonArray>();
             JsonArray hourlyWeatherCodes = sunDoc["hourly"]["weather_code"].as<JsonArray>();
-            JsonArray hourlyPrecip = sunDoc["hourly"]["precipitation_probability"].as<JsonArray>();
-            JsonArray hourlyWind = sunDoc["hourly"]["wind_speed_10m"].as<JsonArray>();
+            JsonArray hourlyPrecip   = sunDoc["hourly"]["precipitation_probability"].as<JsonArray>();
+            JsonArray hourlyWind     = sunDoc["hourly"]["wind_speed_10m"].as<JsonArray>();
+            JsonArray hourlyGusts    = sunDoc["hourly"]["wind_gusts_10m"].as<JsonArray>();
+            JsonArray hourlyPressure = sunDoc["hourly"]["surface_pressure"].as<JsonArray>();
             
             time_t currentTime = time(nullptr);
             data.hourlyCount = 0;
@@ -187,13 +216,21 @@ WeatherData WeatherService::fetch(const String& lat, const String& lon,
             for (size_t i = 0; i < hourlyTimes.size() && data.hourlyCount < 24; i++) {
                 time_t hourTime = hourlyTimes[i].as<time_t>();
                 if (hourTime > currentTime - 1800) { // allow up to 30 mins in past for current hour
-                    data.hourly[data.hourlyCount].timestamp = hourTime;
-                    data.hourly[data.hourlyCount].tempC = hourlyTemps[i].as<float>();
-                    data.hourly[data.hourlyCount].weatherCode = hourlyWeatherCodes[i].as<int>();
+                    data.hourly[data.hourlyCount].timestamp   = hourTime;
+                    data.hourly[data.hourlyCount].tempC        = hourlyTemps[i].as<float>();
+                    data.hourly[data.hourlyCount].weatherCode  = hourlyWeatherCodes[i].as<int>();
                     data.hourly[data.hourlyCount].precipChance = hourlyPrecip[i].as<int>();
-                    data.hourly[data.hourlyCount].windKph = hourlyWind[i].as<float>();
+                    data.hourly[data.hourlyCount].windKph      = hourlyWind[i].as<float>();
+                    data.hourly[data.hourlyCount].windGustKph  = hourlyGusts[i].as<float>();
+                    data.hourly[data.hourlyCount].pressureHpa  = hourlyPressure[i].as<float>();
                     data.hourlyCount++;
                 }
+            }
+
+            // Populate current-conditions scalars from the first valid hourly entry.
+            if (data.hourlyCount > 0) {
+                data.windGustKph = data.hourly[0].windGustKph;
+                data.pressureHpa = data.hourly[0].pressureHpa;
             }
         } else {
             ESP_LOGW(TAG, "Failed to parse Sun JSON");

--- a/lib/Network/WeatherService.h
+++ b/lib/Network/WeatherService.h
@@ -32,6 +32,8 @@ struct HourlyForecast {
     int    weatherCode;  ///< WMO weather code (0-99).
     int    precipChance; ///< Precipitation probability in percent (0–100).
     float  windKph;      ///< Wind speed in km/h.
+    float  windGustKph;  ///< Wind gust speed in km/h.
+    float  pressureHpa;  ///< Surface atmospheric pressure in hPa.
 };
 
 /**
@@ -55,6 +57,12 @@ struct WeatherData {
     int    aqi;                 ///< Air Quality Index (US EPA).
     time_t sunriseTime;         ///< Unix timestamp for today's sunrise.
     time_t sunsetTime;          ///< Unix timestamp for today's sunset.
+    float  windGustKph;         ///< Current wind gust speed in km/h (from first valid hourly entry).
+    float  pressureHpa;         ///< Current surface pressure in hPa (from first valid hourly entry).
+    float  pressureTrend;       ///< Pressure change over last 3 fetch cycles (hPa); populated by AppController.
+    int    pollenGrass;         ///< Peak grass pollen count for the next 8 h (µg/m³); 0 if unavailable.
+    int    pollenBirch;         ///< Peak birch pollen count for the next 8 h (µg/m³); 0 if unavailable.
+    int    pollenWeed;          ///< Peak weed pollen count for the next 8 h (µg/m³); 0 if unavailable.
     bool   valid;               ///< @c true only when the last fetch succeeded.
     time_t fetchTime;           ///< Unix timestamp of the last successful fetch.
 


### PR DESCRIPTION
## Summary

Seven new UI features and quality-of-life improvements, all implemented without adding new API dependencies. All data is derived from the existing Open-Meteo and Google Weather API responses already fetched each cycle.

---

## Changes

### Features

| # | Feature | Where |
|---|---------|-------|
| 1 | **Adaptive sleep interval** — shortens sleep to 10 min when precipitation chance rises > 20 pp across the next 3 hourly windows | `AppController.cpp` |
| 2 | **Pollen / allergen index** — fetches grass, birch, and weed pollen from the Open-Meteo AQI endpoint; shows dominant species and peak count on the dashboard (Y=550) | `WeatherService.cpp/h`, `DisplayManager.cpp` |
| 3 | **Wind gust display** — parses `wind_gusts_10m` from Open-Meteo hourly; shown on dashboard row 4a left column (Y=510) | `WeatherService.cpp/h`, `DisplayManager.cpp` |
| 4 | **Barometric pressure trend** — maintains a 3-reading RTC ring across deep sleep cycles and displays Rising / Steady / Falling on dashboard row 4a right column (Y=510) | `AppController.cpp`, `WeatherService.h`, `DisplayManager.cpp` |
| 5 | **UV recommendation text** — appends inline risk label (Low / Moderate / High / Very High / Extreme) to the UV index row | `DisplayManager.cpp` |
| 6 | **Rain-before-commute badge** — inverted `RAIN` badge in the top-left corner of the clock header when any of the next 3 hourly windows has `precipChance > 60 %` | `DisplayManager.cpp` |
| 7 | **Precipitation type badges on forecast cards** — maps condition string to Storm / Hail / Ice / Snow / Rain badge using `indexOf()` checks; no extra API call | `DisplayManager.cpp` |

### Layout changes (Dashboard)
- Row 4 split into two rows to prevent text overlap:
  - **Y=510** — Gusts (left) / Pressure trend (right)
  - **Y=550** — Pollen (left)
- Environmental dials shifted: Y 570 → 620
- Sunrise/sunset labels: Y 608 → 658
- Horizontal rule: Y 635 → 685
- Tomorrow preview section: all elements +50 px

### Data model (`WeatherService.h`)
New fields added to `HourlyForecast`: `windGustKph`, `pressureHpa`  
New fields added to `WeatherData`: `windGustKph`, `pressureHpa`, `pressureTrend`, `pollenGrass`, `pollenBirch`, `pollenWeed`

### RTC state (`AppController.cpp`)
Two new `RTC_DATA_ATTR` variables survive deep sleep:
- `float rtcPressureRing[3]` — rolling 3-sample pressure history
- `uint8_t rtcPressureCount` — fill counter for the ring

---

## Docs updated
- `CHANGELOG.md` — new entries under `[Unreleased]`
- `docs/features.md` — updated feature catalogue
- `docs/ui-mockups.md` — ASCII diagram and element reference table updated to reflect all new rows and shifted Y-coordinates

---

## Build
```
RAM:   1.2% (used 52560 bytes from 4521984 bytes)
Flash: 22.6% (used 1479068 bytes from 6553600 bytes)
[SUCCESS]
```