### PR TITLE
feat: always-on minimal display mode with 1-minute timer-tick wakeup (#25)

### DIFF
--- a/lib/App/AppController.cpp
+++ b/lib/App/AppController.cpp
@@ -39,6 +39,7 @@ RTC_DATA_ATTR uint8_t     rtcPressureCount = 0;    ///< Number of valid entries 
 RTC_DATA_ATTR int32_t     rtcBatRing[8] = {};      ///< Rolling battery voltage samples (mV) across wakeup cycles for runtime estimation
 RTC_DATA_ATTR uint8_t     rtcBatRingHead = 0;      ///< Next write index for rtcBatRing (ring buffer head)
 RTC_DATA_ATTR uint8_t     rtcBatRingCount = 0;     ///< Number of valid samples in rtcBatRing (clamped to 8)
+RTC_DATA_ATTR uint8_t     rtcMinutesSinceSync = 30; ///< Minutes elapsed since the last weather sync in MinimalAlwaysOn mode; starts at 30 to force an immediate sync on first boot.
 
 // ── Configuration ────────────────────────────────────────────────────────────
 static constexpr uint64_t kSleepDurationUs     = 30ULL * 60ULL * 1000000ULL; // 30 minutes
@@ -72,6 +73,12 @@ void AppController::begin() {
     String locationStr = cfg.city;
     if (cfg.state.length() > 0) {
         locationStr += ", " + cfg.state;
+    }
+
+    // ── Always-On Minimal mode takes its own fast path ────────────────────────
+    if (cfg.display_mode == DisplayMode::MinimalAlwaysOn) {
+        _runMinimalAlwaysOnMode();
+        return;
     }
 
     if (wakeup_reason == ESP_SLEEP_WAKEUP_EXT0) {
@@ -616,5 +623,179 @@ void AppController::_enterDeepSleepForImmediateWakeup() {
     WiFi.disconnect(true);
     WiFi.mode(WIFI_OFF);
     esp_wifi_stop();
+    esp_deep_sleep_start();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Always-On Minimal Mode
+// ─────────────────────────────────────────────────────────────────────────────
+
+void AppController::_runMinimalAlwaysOnMode() {
+    auto wakeup_reason = esp_sleep_get_wakeup_cause();
+    auto cfg           = ConfigManager::getInstance().load();
+    auto& disp         = DisplayManager::getInstance();
+
+    String locationStr = cfg.city;
+    if (cfg.state.length() > 0) locationStr += ", " + cfg.state;
+
+    // Ensure local timezone is applied for RTC reads on all paths.
+    setenv("TZ", cfg.timezone.c_str(), 1);
+    tzset();
+
+    uint8_t syncInterval = (cfg.always_on_sync_interval > 0)
+                           ? cfg.always_on_sync_interval : 30;
+
+    // ── Button (EXT0) wakeup: fall back to full interactive session ──────────
+    if (wakeup_reason == ESP_SLEEP_WAKEUP_EXT0) {
+        ESP_LOGI(TAG, "[MinimalAlwaysOn] EXT0 wakeup — entering interactive session");
+
+        struct tm localTime = {};
+        NTPManager::getInstance().getLocalTime(localTime);
+
+        if (rtcCachedWeather.valid) {
+            disp.setLastKnownIP(rtcLastIP);
+            disp.setLastSyncTime(rtcCachedWeather.fetchTime);
+            disp.setLastError(rtcLastError);
+            disp.drawMinimalMode(rtcCachedWeather, localTime, locationStr);
+        } else {
+            disp.showMessage("No Data Yet", "Weather syncs every few minutes");
+        }
+
+        _runInteractiveSession(locationStr);
+        return;
+    }
+
+    // ── Timer / cold-boot wakeup ─────────────────────────────────────────────
+    if (wakeup_reason == ESP_SLEEP_WAKEUP_TIMER) {
+        rtcMinutesSinceSync++;
+        ESP_LOGI(TAG, "[MinimalAlwaysOn] Timer wakeup — minutes since sync: %u / %u",
+                 rtcMinutesSinceSync, syncInterval);
+    } else {
+        // Cold boot — rtcMinutesSinceSync is initialised to 30 so a sync fires immediately.
+        ESP_LOGI(TAG, "[MinimalAlwaysOn] Cold boot — forcing immediate weather sync");
+    }
+
+    // ── Low-battery guard: extend sleep to 2 hours, skip WiFi ────────────────
+    int32_t batMv = disp.sampleBattery();
+    if (batMv > 0 && batMv < kLowBatThresholdMv) {
+        ESP_LOGW(TAG, "[MinimalAlwaysOn] Low battery (%.2f V) — skipping sync, sleeping 2 h",
+                 batMv / 1000.0f);
+        disp.showMessage("Low Battery",
+                         String("Only ") + String(batMv / 1000.0f, 2) + " V — charge soon");
+        esp_sleep_enable_timer_wakeup(kLowBatSleepUs);
+        _configureEXT0Wakeup();
+        rtcLastError = kErrLowBattery;
+        delay(2000);
+        WiFi.disconnect(true);
+        WiFi.mode(WIFI_OFF);
+        esp_wifi_stop();
+        esp_deep_sleep_start();
+    }
+
+    if (rtcMinutesSinceSync >= syncInterval) {
+        // ═══════════════════════════════════════════════════════════════════════
+        // FULL SYNC CYCLE — WiFi + NTP + weather fetch + full epd_quality render
+        // ═══════════════════════════════════════════════════════════════════════
+        ESP_LOGI(TAG, "[MinimalAlwaysOn] Full sync cycle starting");
+
+        disp.showRefreshingBadge();
+
+        if (WiFiManager::getInstance().isConnected() ||
+            WiFiManager::getInstance().connectBestSTA(cfg.wifi_ssids, cfg.wifi_passes, cfg.wifi_count)) {
+
+            esp_wifi_set_ps(WIFI_PS_MIN_MODEM);
+            strncpy(rtcLastIP, WiFi.localIP().toString().c_str(), sizeof(rtcLastIP) - 1);
+            rtcLastIP[sizeof(rtcLastIP) - 1] = '\0';
+            esp_task_wdt_reset();
+
+            // NTP: full sync every 48 weather-sync cycles (same cadence as standard mode)
+            if (rtcWakeupCount % 48 == 0) {
+                bool ntpOk = NTPManager::getInstance().sync(cfg.ntp_server, cfg.timezone);
+                if (!ntpOk) rtcLastError = kErrNtpFail;
+            } else {
+                setenv("TZ", cfg.timezone.c_str(), 1);
+                tzset();
+            }
+            rtcWakeupCount++;
+            esp_task_wdt_reset();
+
+            WeatherData data = WeatherService::getInstance().fetch(cfg.lat, cfg.lon, cfg.api_key);
+            if (data.valid) {
+                rtcCachedWeather = data;
+                rtcLastError = NTPManager::getInstance().isNtpFailed() ? kErrNtpFail : kErrNone;
+                esp_task_wdt_reset();
+
+                // Rolling pressure ring (same logic as standard mode)
+                if (rtcCachedWeather.pressureHpa > 0.0f) {
+                    rtcPressureRing[0] = rtcPressureRing[1];
+                    rtcPressureRing[1] = rtcPressureRing[2];
+                    rtcPressureRing[2] = rtcCachedWeather.pressureHpa;
+                    if (rtcPressureCount < 3) rtcPressureCount++;
+                    if (rtcPressureCount >= 3)
+                        rtcCachedWeather.pressureTrend = rtcPressureRing[2] - rtcPressureRing[0];
+                }
+            } else {
+                rtcLastError = kErrWeatherFail;
+            }
+        } else {
+            rtcLastError = kErrWiFiFail;
+        }
+
+        disp.setNtpFailed(NTPManager::getInstance().isNtpFailed());
+        disp.setLastError(rtcLastError);
+
+        // Ghost cleanup: full W→B→W cycle before every sync render to prevent
+        // artifact build-up from the 29 fast-refreshes that preceded this draw.
+        disp.ghostingCleanup();
+        rtcGhostCount = 0;
+
+        struct tm localTime = {};
+        NTPManager::getInstance().getLocalTime(localTime);
+
+        if (rtcCachedWeather.valid) {
+            disp.setLastKnownIP(rtcLastIP);
+            disp.setLastSyncTime(rtcCachedWeather.fetchTime);
+            disp.drawMinimalMode(rtcCachedWeather, localTime, locationStr);
+            if (rtcLastError == kErrWeatherFail || rtcLastError == kErrWiFiFail) {
+                disp.showStaleBadge(rtcCachedWeather.fetchTime);
+            }
+        } else {
+            disp.showMessage("Network Error", "Unable to fetch data");
+        }
+
+        rtcMinutesSinceSync = 0;
+        WiFi.disconnect(true);
+        WiFi.mode(WIFI_OFF);
+        esp_wifi_stop();
+
+    } else {
+        // ═══════════════════════════════════════════════════════════════════════
+        // 1-MINUTE TICK CYCLE — clock-only partial refresh, no WiFi
+        // ═══════════════════════════════════════════════════════════════════════
+        ESP_LOGI(TAG, "[MinimalAlwaysOn] Clock-tick cycle (minute %u)", rtcMinutesSinceSync);
+
+        struct tm localTime = {};
+        NTPManager::getInstance().getLocalTime(localTime);
+
+        disp.updateMinimalClock(localTime, NTPManager::getInstance().isNtpFailed());
+    }
+
+    _enterMinimalDeepSleep();
+}
+
+void AppController::_enterMinimalDeepSleep() {
+    // Sleep until the top of the next minute so wakeups land close to HH:MM:00.
+    struct tm now = {};
+    NTPManager::getInstance().getLocalTime(now);
+    int secsUntilNextMin = 60 - now.tm_sec;
+    if (secsUntilNextMin <= 0 || secsUntilNextMin > 60) secsUntilNextMin = 60;
+
+    uint64_t sleepUs = (uint64_t)secsUntilNextMin * 1000000ULL;
+    ESP_LOGI(TAG, "[MinimalAlwaysOn] Sleeping %d s until next minute boundary", secsUntilNextMin);
+
+    esp_sleep_enable_timer_wakeup(sleepUs);
+    _configureEXT0Wakeup();
+
+    delay(200);
     esp_deep_sleep_start();
 }

--- a/lib/App/AppController.h
+++ b/lib/App/AppController.h
@@ -42,6 +42,24 @@ private:
      * without bypassing the established WiFi → fetch → render sequence.
      */
     void _enterDeepSleepForImmediateWakeup();
+
+    /**
+     * @brief Run the Always-On Minimal display mode state machine.
+     *
+     * On timer wakeup, either performs a full WiFi sync (when
+     * rtcMinutesSinceSync >= always_on_sync_interval) or a fast clock-only
+     * partial refresh, then sleeps until the next minute boundary.
+     * On button (EXT0) wakeup, falls through to the standard interactive session.
+     */
+    void _runMinimalAlwaysOnMode();
+
+    /**
+     * @brief Enter deep sleep until the top of the next minute.
+     *
+     * Used exclusively by the minimal always-on mode to produce 1-minute
+     * timer-tick wakeups that land as close as possible to HH:MM:00.
+     */
+    void _enterMinimalDeepSleep();
 };
 
 #endif // APP_CONTROLLER_H

--- a/lib/Config/ConfigManager.cpp
+++ b/lib/Config/ConfigManager.cpp
@@ -108,6 +108,8 @@ WeatherConfig ConfigManager::load() const {
         cfg.night_mode_end   = _prefs.getInt("nm_end",   6);
         cfg.webhook_url = _decryptString(_prefs.getString("webhook_url", ""));
         cfg.pin_hash    = _prefs.getString("pin_hash",   "");
+        cfg.display_mode = static_cast<DisplayMode>(_prefs.getUChar("disp_mode", 0));
+        cfg.always_on_sync_interval = _prefs.getInt("ao_sync_int", 30);
         _prefs.end();
 
         xSemaphoreGive(_mutex);
@@ -171,6 +173,8 @@ void ConfigManager::save(const WeatherConfig& cfg) {
         else
             _prefs.remove("webhook_url");
         _prefs.putString("pin_hash",   cfg.pin_hash);
+        _prefs.putUChar("disp_mode",  static_cast<uint8_t>(cfg.display_mode));
+        _prefs.putInt("ao_sync_int",  cfg.always_on_sync_interval > 0 ? cfg.always_on_sync_interval : 30);
         _prefs.putBool("cfg_encv",     true);
         _prefs.putBool("provisioned",  true);
         _prefs.end();

--- a/lib/Config/ConfigManager.h
+++ b/lib/Config/ConfigManager.h
@@ -15,6 +15,15 @@
 #include <freertos/semphr.h>
 
 /**
+ * @enum DisplayMode
+ * @brief Controls the screen-update strategy used between deep-sleep cycles.
+ */
+enum class DisplayMode : uint8_t {
+    Standard       = 0, ///< Dense weather dashboard; wakes once per sync_interval_m.
+    MinimalAlwaysOn = 1, ///< Sparse clock+weather layout; wakes every minute for a clock tick and every always_on_sync_interval minutes for a weather sync.
+};
+
+/**
  * @struct WeatherConfig
  * @brief Plain-data bag holding all user-configurable settings.
  */
@@ -37,6 +46,8 @@ struct WeatherConfig {
     int    night_mode_end   = 6;  ///< Hour (0–23) at which overnight fetch-skipping ends (default 6). Set equal to night_mode_start to disable.
     String pin_hash;            ///< SHA-256 hex digest of the 4–8 digit security PIN.
     String webhook_url;         ///< Optional webhook URL triggered by physical action.
+    DisplayMode display_mode = DisplayMode::Standard; ///< Screen-update strategy (Standard or MinimalAlwaysOn).
+    int    always_on_sync_interval = 30; ///< Weather sync interval in minutes for MinimalAlwaysOn mode (default 30).
 };
 
 /**

--- a/lib/Display/DisplayManager.cpp
+++ b/lib/Display/DisplayManager.cpp
@@ -965,6 +965,144 @@ void DisplayManager::updateClockOnly(const struct tm& localTime, bool ntpFailed)
     clockSprite.deleteSprite();
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Minimal Always-On Mode — full screen render
+// ─────────────────────────────────────────────────────────────────────────────
+
+void DisplayManager::drawMinimalMode(const WeatherData& data,
+                                     const struct tm& localTime,
+                                     const String& city) {
+    M5.Display.setEpdMode(epd_mode_t::epd_quality);
+    clear();
+    _canvas.fillSprite(TFT_WHITE);
+
+    // ── Battery (top-right corner) ────────────────────────────────────────────
+    _drawBattery();
+
+    // ── Clock block (Y: 180–400) ──────────────────────────────────────────────
+    char timeBuf[32], dateBuf[48];
+    strftime(timeBuf, sizeof(timeBuf), "%l:%M %p", &localTime);
+    strftime(dateBuf,  sizeof(dateBuf),  "%A, %B %d", &localTime);
+
+    // Trim leading space that %l inserts for single-digit hours
+    const char* timeStr = (timeBuf[0] == ' ') ? timeBuf + 1 : timeBuf;
+
+    _canvas.setTextColor(TFT_BLACK);
+    _canvas.setTextDatum(MC_DATUM);
+
+    _canvas.setFont(&fonts::FreeSansBold24pt7b);
+    _canvas.setTextSize(3);
+    _canvas.drawString(timeStr, kWidth / 2, 260);
+
+    // NTP failure badge — tiny "NTP!" to the right of the time
+    if (_ntpFailed) {
+        _canvas.setFont(nullptr);
+        _canvas.setTextSize(1);
+        _canvas.setTextDatum(TL_DATUM);
+        _canvas.drawString("NTP!", kWidth - 44, 22);
+        _canvas.setTextDatum(MC_DATUM);
+    }
+
+    _canvas.setFont(&fonts::FreeSans18pt7b);
+    _canvas.setTextSize(1);
+    _canvas.drawString(dateBuf, kWidth / 2, 370);
+
+    // City label — uses a slightly smaller font to leave breathing room
+    if (!city.isEmpty()) {
+        _canvas.setFont(&fonts::FreeSans12pt7b);
+        _canvas.drawString(city, kWidth / 2, 420);
+    }
+
+    _canvas.setTextDatum(TL_DATUM);
+
+    // ── Divider ───────────────────────────────────────────────────────────────
+    _canvas.drawFastHLine(60, 460, kWidth - 120, TFT_BLACK);
+
+    // ── Weather block (Y: 540–780) ────────────────────────────────────────────
+    if (data.valid) {
+        // Weather icon centred at X = kWidth/2, top at Y = 520
+        _drawWeatherIcon(data.condition, kWidth / 2 - 50, 520, 80);
+
+        // Temperature
+        char tempBuf[24], hlBuf[32];
+        snprintf(tempBuf, sizeof(tempBuf), "%.1f C", data.tempC);
+        if (data.forecastDays > 0) {
+            snprintf(hlBuf, sizeof(hlBuf), "H: %.0f  L: %.0f",
+                     data.forecast[0].maxTempC, data.forecast[0].minTempC);
+        } else {
+            hlBuf[0] = '\0';
+        }
+
+        _canvas.setFont(&fonts::FreeSansBold24pt7b);
+        _canvas.setTextSize(1);
+        _canvas.setTextDatum(MC_DATUM);
+        _canvas.setTextColor(TFT_BLACK);
+        _canvas.drawString(tempBuf, kWidth / 2, 668);
+
+        _canvas.setFont(&fonts::FreeSans18pt7b);
+        _canvas.drawString(data.condition, kWidth / 2, 710);
+
+        _canvas.setFont(&fonts::FreeSans12pt7b);
+        _canvas.drawString(hlBuf, kWidth / 2, 750);
+
+        _canvas.setTextDatum(TL_DATUM);
+    }
+
+    // ── Last-updated timestamp (bottom strip) ─────────────────────────────────
+    _drawLastUpdated(data.fetchTime);
+
+    _canvas.pushSprite(0, 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Minimal Always-On Mode — clock-only partial refresh
+// ─────────────────────────────────────────────────────────────────────────────
+
+void DisplayManager::updateMinimalClock(const struct tm& localTime, bool ntpFailed) {
+    // Bounding box that encompasses the clock text + date + city label drawn
+    // by drawMinimalMode(), with a small top/bottom margin to guarantee a clean erase.
+    constexpr int kClockTop = 180;
+    constexpr int kClockH   = 280; // covers Y 180–460
+
+    char timeBuf[32], dateBuf[48];
+    strftime(timeBuf, sizeof(timeBuf), "%l:%M %p", &localTime);
+    strftime(dateBuf,  sizeof(dateBuf),  "%A, %B %d", &localTime);
+    const char* timeStr = (timeBuf[0] == ' ') ? timeBuf + 1 : timeBuf;
+
+    M5Canvas minSprite(&M5.Display);
+    minSprite.setColorDepth(1);
+    minSprite.createSprite(kWidth, kClockH);
+    minSprite.fillSprite(TFT_WHITE);
+
+    minSprite.setTextColor(TFT_BLACK, TFT_WHITE);
+    minSprite.setTextDatum(MC_DATUM);
+
+    // Large time string
+    minSprite.setFont(&fonts::FreeSansBold24pt7b);
+    minSprite.setTextSize(3);
+    minSprite.drawString(timeStr, kWidth / 2, 260 - kClockTop);
+
+    // NTP badge
+    if (ntpFailed) {
+        minSprite.setFont(nullptr);
+        minSprite.setTextSize(1);
+        minSprite.setTextDatum(TL_DATUM);
+        minSprite.drawString("NTP!", kWidth - 44, 22 - kClockTop > 0 ? 22 - kClockTop : 0);
+        minSprite.setTextDatum(MC_DATUM);
+    }
+
+    // Date sub-label
+    minSprite.setFont(&fonts::FreeSans18pt7b);
+    minSprite.setTextSize(1);
+    minSprite.drawString(dateBuf, kWidth / 2, 370 - kClockTop);
+
+    minSprite.setTextDatum(TL_DATUM);
+
+    M5.Display.setEpdMode(epd_mode_t::epd_fastest);
+    minSprite.pushSprite(0, kClockTop);
+    minSprite.deleteSprite();
+}
+
 // ── Alert banner ─────────────────────────────────────────────────────────────
 void DisplayManager::_drawAlertBanner(const char* headline) {
     if (!headline || headline[0] == '\0') return;

--- a/lib/Display/DisplayManager.h
+++ b/lib/Display/DisplayManager.h
@@ -245,6 +245,35 @@ public:
      */
     int getBatLevel() const { return _cachedBatLevel; }
 
+    /**
+     * @brief Render the full Minimal Always-On screen.
+     *
+     * Sparse layout designed to minimise ghosting from repeated fast-refreshes:
+     *   - Battery gauge at the top of the screen.
+     *   - Large clock centred at Y ≈ 200–420 (the only region updated every minute).
+     *   - Weather icon + current temperature + H/L centred at Y ≈ 600–800
+     *     (refreshed only every @p always_on_sync_interval minutes).
+     *
+     * Uses epd_quality mode and a full clear to eliminate ghost artefacts that
+     * accumulate from 29 prior epd_fastest clock-tick refreshes.
+     *
+     * @param data       Latest WeatherData (must be valid).
+     * @param localTime  Current local time (for the clock block).
+     * @param city       Location string shown below the clock.
+     */
+    void drawMinimalMode(const WeatherData& data, const struct tm& localTime, const String& city);
+
+    /**
+     * @brief Partially refresh only the clock block on the Minimal Always-On screen.
+     *
+     * Redraws the bounding box x=0, y=180, w=540, h=220 using epd_fastest so
+     * only the time digits change every minute without flashing the entire panel.
+     *
+     * @param localTime  Current local time.
+     * @param ntpFailed  When @c true a small "NTP!" badge is drawn next to the time.
+     */
+    void updateMinimalClock(const struct tm& localTime, bool ntpFailed = false);
+
 private:
     DisplayManager() = default;
 

--- a/lib/Provisioning/WebServer.cpp
+++ b/lib/Provisioning/WebServer.cpp
@@ -203,6 +203,14 @@ void ProvisionWebServer::begin(uint16_t port) {
         cfg.webhook_url     = getOpt("webhook_url");
         cfg.pin_hash        = pinHash;
 
+        // Display mode
+        String dispModeStr = getOpt("display_mode");
+        cfg.display_mode = (dispModeStr == "minimal_always_on")
+                           ? DisplayMode::MinimalAlwaysOn
+                           : DisplayMode::Standard;
+        int aoSyncInt = getOpt("ao_sync_interval").toInt();
+        cfg.always_on_sync_interval = (aoSyncInt > 0) ? aoSyncInt : 30;
+
         if (_saveCallback) {
             _saveCallback(cfg);
         }

--- a/lib/Provisioning/html/provision.h
+++ b/lib/Provisioning/html/provision.h
@@ -150,6 +150,25 @@ button:hover{opacity:.88}
 <div class="f"><label>Webhook URL (optional)</label><input name="webhook_url" placeholder="http://..."></div>
 </fieldset>
 <fieldset>
+<legend>&#128247; Display Mode</legend>
+<div class="f"><label>Screen Update Strategy</label>
+<select name="display_mode" id="display_mode" onchange="toggleAO()">
+<option value="standard" selected>Standard — dense weather dashboard (30-min wakeup)</option>
+<option value="minimal_always_on">Minimal Always-On — live clock + weather (1-min tick)</option>
+</select>
+<p class="hint">Standard: full weather dashboard updated every sync interval. Minimal Always-On: sparse clock+weather layout with 1-minute clock ticks and periodic WiFi sync.</p>
+</div>
+<div class="f" id="ao_row" style="display:none"><label>Always-On Weather Sync Interval (minutes)</label>
+<select name="ao_sync_interval" id="ao_sync_interval">
+<option value="15">Every 15 minutes</option>
+<option value="30" selected>Every 30 minutes</option>
+<option value="60">Every 1 hour</option>
+<option value="120">Every 2 hours</option>
+</select>
+<p class="hint">How often to wake WiFi and fetch fresh weather data between clock ticks.</p>
+</div>
+</fieldset>
+<fieldset>
 <legend>&#128274; Security PIN</legend>
 <div class="f"><label>PIN (4–8 digits)</label><input type="password" name="pin" id="pin" inputmode="numeric" pattern="[0-9]{4,8}" placeholder="&bull;&bull;&bull;&bull;" required></div>
 <div class="f"><label>Confirm PIN</label><input type="password" name="pin2" id="pin2" inputmode="numeric" pattern="[0-9]{4,8}" placeholder="&bull;&bull;&bull;&bull;" required></div>
@@ -166,6 +185,7 @@ button:hover{opacity:.88}
 <script>
 var wifis=[{s:'',p:''}];
 function hesc(v){return v.replace(/&/g,'&amp;').replace(/"/g,'&quot;');}
+function toggleAO(){var m=document.getElementById('display_mode').value;document.getElementById('ao_row').style.display=(m==='minimal_always_on'?'block':'none');}
 function syncW(){
   var e=document.querySelectorAll('.wi');
   for(var i=0;i<e.length&&i<wifis.length;i++){


### PR DESCRIPTION
## Summary

Closes #25

Adds a new **Minimal Always-On** display mode that transforms the M5Paper from a periodic snapshot device into a live desktop clock. The device wakes every minute to tick the clock, and only enables WiFi every N minutes (configurable, default 30) for a weather sync.

---

## Deep Sleep State Machine (`AppController`)

- Added `RTC_DATA_ATTR uint8_t rtcMinutesSinceSync` (initialised to `30` to force an immediate weather sync on first boot) that persists across deep sleep.
- `begin()` now routes to `_runMinimalAlwaysOnMode()` when `DisplayMode::MinimalAlwaysOn` is configured; the standard mode path is completely unaffected.
- `_runMinimalAlwaysOnMode()` implements two wakeup branches:
  - **EXT0 (button):** renders the minimal screen, then enters the existing interactive session so swipes/taps continue to work.
  - **Timer / cold-boot:** increments `rtcMinutesSinceSync` and either runs a **full sync cycle** (`ghostingCleanup` + WiFi + NTP + weather fetch + `drawMinimalMode`, `epd_quality`) when `rtcMinutesSinceSync >= syncInterval`, or a **1-minute tick** (`updateMinimalClock`, `epd_fastest` partial refresh of Y:180–460 only) with WiFi radio off.
- `_enterMinimalDeepSleep()` calculates exact microseconds to the top of the next minute for precise HH:MM:00 wakeup alignment.

---

## Minimal UI Layout (`DisplayManager`)

Sparse layout to minimise ghosting from up to 29 consecutive fast-refreshes between full clears:

```
Y ≈  ┌──────────────────────────────────────────┐
   0 │  [Battery]                         65%   │
     │                                          │
 260 │               10:42 AM                   │  ← updated every minute (epd_fastest)
 370 │            Tuesday, April 08             │
 420 │              Chicago, IL                 │
     │  ──────────────────────────────────────  │
 600 │              [Cloud Icon]                │  ← updated only on sync cycle
 668 │                 18.5 C                   │
 710 │             Partly Cloudy                │
 750 │           H: 22  L: 14                   │
 960 └──────────────────────────────────────────┘
```

- **`drawMinimalMode()`** — full `epd_quality` render on every weather sync cycle.
- **`updateMinimalClock()`** — `epd_fastest` partial refresh of Y:180–460 only; weather section is never disturbed on 1-minute ticks.
- **Ghost artefact control:** `ghostingCleanup()` (W→B→W) runs before every sync render to clear accumulated artefacts from the preceding fast-refresh cycles.

---

## Configuration

| Field | NVS key | Default | Description |
|-------|---------|---------|-------------|
| `display_mode` | `disp_mode` | `Standard` | `Standard` or `MinimalAlwaysOn` |
| `always_on_sync_interval` | `ao_sync_int` | `30` | Weather sync cadence in minutes |

- `ConfigManager.h` — new `DisplayMode` enum and two fields on `WeatherConfig`.
- `ConfigManager.cpp` — load/save via NVS keys `disp_mode` / `ao_sync_int`.
- `WebServer.cpp` — parses `display_mode` and `ao_sync_interval` from the POST form.
- `provision.h` — new **Display Mode** fieldset; the sync-interval select is conditionally revealed by `toggleAO()` JS when Minimal Always-On is chosen.

---

## Files Changed

| File | Change |
|------|--------|
| `lib/Config/ConfigManager.h` | `DisplayMode` enum, new `WeatherConfig` fields |
| `lib/Config/ConfigManager.cpp` | NVS load/save for new fields |
| `lib/App/AppController.h` | Declared `_runMinimalAlwaysOnMode()`, `_enterMinimalDeepSleep()` |
| `lib/App/AppController.cpp` | RTC variable, routing in `begin()`, full state machine implementation |
| `lib/Display/DisplayManager.h` | Declared `drawMinimalMode()`, `updateMinimalClock()` |
| `lib/Display/DisplayManager.cpp` | Implemented both rendering methods |
| `lib/Provisioning/WebServer.cpp` | Parse new form fields |
| `lib/Provisioning/html/provision.h` | Display Mode fieldset + `toggleAO()` JS |