### PR TITLE
feat(display): add widget base class and page engine for component-based UI

### DIFF
--- a/lib/App/AppController.cpp
+++ b/lib/App/AppController.cpp
@@ -298,6 +298,9 @@ void AppController::_runInteractiveSession(const String& locationStr) {
         bool activity = false;
         esp_task_wdt_reset(); // keep WDT alive: interactive session is running normally
 
+        // Process touch and buttons on the main loop (same I2C context as RTC reads).
+        input.pollInput();
+
         struct tm localTime = {};
         NTPManager::getInstance().getLocalTime(localTime);
         if (lastMinute == -1) lastMinute = localTime.tm_min;

--- a/lib/Display/DisplayManager.cpp
+++ b/lib/Display/DisplayManager.cpp
@@ -330,7 +330,7 @@ void DisplayManager::drawPageDashboard(const WeatherData& data,
     _canvas.setTextColor(TFT_BLACK); // Ensure canvas texts have transparent backgrounds
     
     _canvas.setFont(&fonts::FreeSansBold24pt7b);
-    _canvas.setTextSize(2);
+    _canvas.setTextSize(1.5f);
     // Draw "2:51 PM" at Y=20
     _canvas.drawCentreString(timeBuf, kWidth / 2, 20);
 
@@ -340,7 +340,7 @@ void DisplayManager::drawPageDashboard(const WeatherData& data,
         _canvas.setTextSize(1);
         _canvas.drawString("NTP!", kWidth - 44, 22);
         _canvas.setFont(&fonts::FreeSansBold24pt7b);
-        _canvas.setTextSize(2);
+        _canvas.setTextSize(1.5f);
     }
 
     // Rain-before-commute badge — shown when precipChance >60% within the next 3 forecast hours.
@@ -954,7 +954,7 @@ void DisplayManager::updateClockOnly(const struct tm& localTime, bool ntpFailed)
 
     // ── Time string (drawn last so it renders on top of the white background) ──
     clockSprite.setFont(&fonts::FreeSansBold24pt7b);
-    clockSprite.setTextSize(2);
+    clockSprite.setTextSize(1.5f);
     clockSprite.setTextColor(TFT_BLACK, TFT_WHITE);
     clockSprite.setTextDatum(TC_DATUM);
     clockSprite.drawString(timeBuf, kWidth / 2, 20);
@@ -992,7 +992,7 @@ void DisplayManager::drawMinimalMode(const WeatherData& data,
     _canvas.setTextDatum(MC_DATUM);
 
     _canvas.setFont(&fonts::FreeSansBold24pt7b);
-    _canvas.setTextSize(3);
+    _canvas.setTextSize(1.5f);
     _canvas.drawString(timeStr, kWidth / 2, 260);
 
     // NTP failure badge — tiny "NTP!" to the right of the time
@@ -1080,7 +1080,7 @@ void DisplayManager::updateMinimalClock(const struct tm& localTime, bool ntpFail
 
     // Large time string
     minSprite.setFont(&fonts::FreeSansBold24pt7b);
-    minSprite.setTextSize(3);
+    minSprite.setTextSize(1.5f);
     minSprite.drawString(timeStr, kWidth / 2, 260 - kClockTop);
 
     // NTP badge

--- a/lib/Display/DisplayManager.cpp
+++ b/lib/Display/DisplayManager.cpp
@@ -1,4 +1,5 @@
 #include "DisplayManager.h"
+#include "WeatherIconHelper.h"
 #include "weather_bitmaps.h"
 #include <WiFi.h>
 #include <qrcode.h>
@@ -1638,78 +1639,7 @@ void DisplayManager::_drawWindRose(int cx, int cy, int r, int direction) {
 }
 
 void DisplayManager::_drawWeatherIcon(const char* condition, int x, int y, int size) {
-    String cond = condition;
-    cond.toLowerCase();
-
-    // Select the best matching icon from the IcoMoon weather icon set.
-    // Conditions arrive as Google Weather API description text (e.g. "Heavy Rain").
-    const uint8_t* bmp = icon_cloudy_bmp; // default fallback
-
-    if (cond.indexOf("tornado") >= 0) {
-        bmp = icon_tornado_bmp;
-    } else if (cond.indexOf("hurricane") >= 0 || cond.indexOf("tropical storm") >= 0) {
-        bmp = icon_hurricane_bmp;
-    } else if (cond.indexOf("hail") >= 0) {
-        bmp = icon_hail_bmp;
-    } else if (cond.indexOf("thunder") >= 0 || cond.indexOf("t-storm") >= 0 || cond.indexOf("tstorm") >= 0) {
-        bmp = icon_thunder_bmp;
-    } else if (cond.indexOf("freezing") >= 0) {
-        bmp = icon_freezing_rain_bmp;
-    } else if (cond.indexOf("sleet") >= 0 || cond.indexOf("mixed") >= 0) {
-        bmp = icon_sleet_bmp;
-    } else if (cond.indexOf("blowing snow") >= 0 || cond.indexOf("blizzard") >= 0) {
-        bmp = icon_blowing_snow_bmp;
-    } else if (cond.indexOf("heavy snow") >= 0) {
-        bmp = icon_heavy_snow_bmp;
-    } else if (cond.indexOf("snow") >= 0 || cond.indexOf("flurr") >= 0) {
-        bmp = icon_snow_bmp;
-    } else if (cond.indexOf("heavy shower") >= 0 || cond.indexOf("heavy rain") >= 0) {
-        bmp = icon_heavy_showers_bmp;
-    } else if (cond.indexOf("drizzle") >= 0) {
-        bmp = icon_drizzle_bmp;
-    } else if (cond.indexOf("rain") >= 0 || cond.indexOf("shower") >= 0) {
-        bmp = icon_rain_bmp;
-    } else if (cond.indexOf("fog") >= 0) {
-        bmp = icon_foggy_bmp;
-    } else if (cond.indexOf("haze") >= 0 || cond.indexOf("mist") >= 0) {
-        bmp = icon_haze_bmp;
-    } else if (cond.indexOf("smoke") >= 0 || cond.indexOf("ash") >= 0) {
-        bmp = icon_smoky_bmp;
-    } else if (cond.indexOf("dust") >= 0 || cond.indexOf("sand") >= 0) {
-        bmp = icon_haze_bmp;
-    } else if (cond.indexOf("blustery") >= 0 || cond.indexOf("squall") >= 0) {
-        bmp = icon_blustery_bmp;
-    } else if (cond.indexOf("wind") >= 0 || cond.indexOf("breezy") >= 0) {
-        bmp = icon_windy_bmp;
-    } else if (cond.indexOf("mostly cloudy") >= 0 || cond.indexOf("overcast") >= 0) {
-        bmp = icon_mostly_cloudy_bmp;
-    } else if (cond.indexOf("partly cloudy") >= 0 || cond.indexOf("partly sunny") >= 0) {
-        bmp = icon_partly_cloudy_bmp;
-    } else if (cond.indexOf("cloudy") >= 0) {
-        bmp = icon_cloudy_bmp;
-    } else if (cond.indexOf("sun") >= 0 || cond.indexOf("clear") >= 0 || cond.indexOf("fair") >= 0) {
-        bmp = icon_clear_bmp;
-    } else if (cond.indexOf("n/a") >= 0 || cond.indexOf("unknown") >= 0 || cond.length() == 0) {
-        bmp = icon_not_available_bmp;
-    }
-
-    // Nearest-neighbour scale the 32x32 XBM to size×size pixels, centred on (x, y).
-    static constexpr int SRC_W = 32;
-    static constexpr int SRC_H = 32;
-    static constexpr int BYTES_PER_ROW = (SRC_W + 7) / 8; // 4
-    int out_w = size;
-    int out_h = size;
-    int draw_x = x - out_w / 2;
-    int draw_y = y - out_h / 2;
-    for (int oy = 0; oy < out_h; oy++) {
-        int sy = oy * SRC_H / out_h;
-        for (int ox = 0; ox < out_w; ox++) {
-            int sx = ox * SRC_W / out_w;
-            uint8_t byte = pgm_read_byte(&bmp[sy * BYTES_PER_ROW + sx / 8]);
-            bool dark = (byte >> (sx % 8)) & 1;
-            _canvas.drawPixel(draw_x + ox, draw_y + oy, dark ? TFT_BLACK : TFT_WHITE);
-        }
-    }
+    drawWeatherIconOnCanvas(_canvas, condition, x, y, size);
 }
 
 // ── Settings page icons ───────────────────────────────────────────────────────

--- a/lib/Display/IDisplayController.h
+++ b/lib/Display/IDisplayController.h
@@ -1,0 +1,78 @@
+/**
+ * @file IDisplayController.h
+ * @brief Hardware-agnostic drawing interface for the Widget / Page engine.
+ *
+ * IDisplayController abstracts all drawing primitives so that Widget subclasses
+ * never include M5GFX headers directly.  The concrete M5CanvasController
+ * implementation (M5CanvasController.h) maps every call to the appropriate
+ * LGFX / M5Canvas API.
+ */
+#ifndef IDISPLAY_CONTROLLER_H
+#define IDISPLAY_CONTROLLER_H
+
+#include <stdint.h>
+
+// ── Font selector ─────────────────────────────────────────────────────────────
+enum class WidgetFont {
+    Tiny,        // nullptr  — system default raster font
+    Small,       // FreeSans9pt7b
+    SmallBold,   // FreeSansBold9pt7b
+    Medium,      // FreeSans12pt7b
+    Large,       // FreeSans18pt7b
+    LargeBold,   // FreeSansBold18pt7b
+    XLarge,      // FreeSans24pt7b
+    XLargeBold,  // FreeSansBold24pt7b
+};
+
+// ── Text alignment ────────────────────────────────────────────────────────────
+enum class WidgetDatum {
+    TopLeft,
+    TopCenter,
+    TopRight,
+    MiddleLeft,
+    MiddleCenter,
+    MiddleRight,
+};
+
+// ── Interface ─────────────────────────────────────────────────────────────────
+class IDisplayController {
+public:
+    virtual ~IDisplayController() = default;
+
+    // Shapes
+    virtual void fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint32_t color) = 0;
+    virtual void drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint32_t color) = 0;
+    virtual void drawRoundRect(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r, uint32_t color) = 0;
+    virtual void fillCircle(int16_t x, int16_t y, int16_t r, uint32_t color) = 0;
+    virtual void drawCircle(int16_t x, int16_t y, int16_t r, uint32_t color) = 0;
+    virtual void drawArc(int16_t x, int16_t y, int16_t r0, int16_t r1,
+                         float a0, float a1, uint32_t color) = 0;
+    virtual void fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
+                              int16_t x2, int16_t y2, uint32_t color) = 0;
+    virtual void drawFastHLine(int16_t x, int16_t y, int16_t w, uint32_t color) = 0;
+    virtual void drawFastVLine(int16_t x, int16_t y, int16_t h, uint32_t color) = 0;
+    virtual void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint32_t color) = 0;
+    virtual void drawPixel(int16_t x, int16_t y, uint32_t color) = 0;
+
+    // Text
+    virtual void setFont(WidgetFont font) = 0;
+    virtual void setTextSize(float size) = 0;
+    virtual void setTextColor(uint32_t color) = 0;
+    virtual void setTextDatum(WidgetDatum datum) = 0;
+    virtual void drawString(const char* text, int16_t x, int16_t y) = 0;
+    virtual void drawCentreString(const char* text, int16_t x, int16_t y) = 0;
+
+    // Weather icon (condition string → nearest-neighbour scaled XBM bitmap)
+    virtual void drawWeatherIcon(const char* condition, int16_t x, int16_t y, int16_t size) = 0;
+
+    // E-ink partial refresh: push the bounding box region to the physical panel.
+    // Concrete implementations should use epd_fastest mode and limit the push to
+    // the supplied rectangle to avoid a full-panel flash on every widget update.
+    virtual void flushBoundingBox(int16_t x, int16_t y, int16_t w, int16_t h) = 0;
+
+    // Display dimensions (needed by PageBase for full-screen flush)
+    virtual int16_t getWidth()  const = 0;
+    virtual int16_t getHeight() const = 0;
+};
+
+#endif // IDISPLAY_CONTROLLER_H

--- a/lib/Display/M5CanvasController.h
+++ b/lib/Display/M5CanvasController.h
@@ -1,0 +1,111 @@
+/**
+ * @file M5CanvasController.h
+ * @brief Concrete IDisplayController that delegates drawing to an M5Canvas.
+ *
+ * M5CanvasController wraps a reference to an existing M5Canvas (LGFX_Sprite)
+ * and maps:
+ *   - WidgetFont enum  → LGFX font pointers (FreeSans / FreeSansBold family)
+ *   - WidgetDatum enum → LGFX text-datum constants (TL_DATUM, TC_DATUM …)
+ *   - drawWeatherIcon  → drawWeatherIconOnCanvas<M5Canvas> (WeatherIconHelper.h)
+ *   - flushBoundingBox → epd_fastest partial refresh of the widget's rectangle
+ *
+ * flushBoundingBox() uses M5.Display.setClipRect() to restrict the canvas
+ * push to the widget's bounding box, so the e-ink panel only cycles the pixels
+ * that actually changed.  The full-screen canvas (_canvas) is always the single
+ * source of truth; no per-widget sub-sprites are needed for the basic case.
+ */
+#ifndef M5_CANVAS_CONTROLLER_H
+#define M5_CANVAS_CONTROLLER_H
+
+#include "IDisplayController.h"
+#include "WeatherIconHelper.h"
+#include <M5Unified.h>
+
+class M5CanvasController : public IDisplayController {
+    M5Canvas& _canvas;
+
+    static const lgfx::IFont* _toFont(WidgetFont f) {
+        switch (f) {
+            case WidgetFont::Small:      return &fonts::FreeSans9pt7b;
+            case WidgetFont::SmallBold:  return &fonts::FreeSansBold9pt7b;
+            case WidgetFont::Medium:     return &fonts::FreeSans12pt7b;
+            case WidgetFont::Large:      return &fonts::FreeSans18pt7b;
+            case WidgetFont::LargeBold:  return &fonts::FreeSansBold18pt7b;
+            case WidgetFont::XLarge:     return &fonts::FreeSans24pt7b;
+            case WidgetFont::XLargeBold: return &fonts::FreeSansBold24pt7b;
+            default:                     return nullptr; // Tiny → system raster font
+        }
+    }
+
+    static uint8_t _toDatum(WidgetDatum d) {
+        switch (d) {
+            case WidgetDatum::TopLeft:      return TL_DATUM;
+            case WidgetDatum::TopCenter:    return TC_DATUM;
+            case WidgetDatum::TopRight:     return TR_DATUM;
+            case WidgetDatum::MiddleLeft:   return ML_DATUM;
+            case WidgetDatum::MiddleCenter: return MC_DATUM;
+            case WidgetDatum::MiddleRight:  return MR_DATUM;
+            default:                        return TL_DATUM;
+        }
+    }
+
+public:
+    explicit M5CanvasController(M5Canvas& canvas) : _canvas(canvas) {}
+
+    // ── Shapes ────────────────────────────────────────────────────────────────
+    void fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint32_t c) override
+        { _canvas.fillRect(x, y, w, h, c); }
+    void drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint32_t c) override
+        { _canvas.drawRect(x, y, w, h, c); }
+    void drawRoundRect(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r, uint32_t c) override
+        { _canvas.drawRoundRect(x, y, w, h, r, c); }
+    void fillCircle(int16_t x, int16_t y, int16_t r, uint32_t c) override
+        { _canvas.fillCircle(x, y, r, c); }
+    void drawCircle(int16_t x, int16_t y, int16_t r, uint32_t c) override
+        { _canvas.drawCircle(x, y, r, c); }
+    void drawArc(int16_t x, int16_t y, int16_t r0, int16_t r1,
+                 float a0, float a1, uint32_t c) override
+        { _canvas.drawArc(x, y, r0, r1, a0, a1, c); }
+    void fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
+                      int16_t x2, int16_t y2, uint32_t c) override
+        { _canvas.fillTriangle(x0, y0, x1, y1, x2, y2, c); }
+    void drawFastHLine(int16_t x, int16_t y, int16_t w, uint32_t c) override
+        { _canvas.drawFastHLine(x, y, w, c); }
+    void drawFastVLine(int16_t x, int16_t y, int16_t h, uint32_t c) override
+        { _canvas.drawFastVLine(x, y, h, c); }
+    void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint32_t c) override
+        { _canvas.drawLine(x0, y0, x1, y1, c); }
+    void drawPixel(int16_t x, int16_t y, uint32_t c) override
+        { _canvas.drawPixel(x, y, c); }
+
+    // ── Text ──────────────────────────────────────────────────────────────────
+    void setFont(WidgetFont f) override     { _canvas.setFont(_toFont(f)); }
+    void setTextSize(float s) override      { _canvas.setTextSize(s); }
+    void setTextColor(uint32_t c) override  { _canvas.setTextColor(c); }
+    void setTextDatum(WidgetDatum d) override { _canvas.setTextDatum(_toDatum(d)); }
+    void drawString(const char* t, int16_t x, int16_t y) override
+        { _canvas.drawString(t, x, y); }
+    void drawCentreString(const char* t, int16_t x, int16_t y) override
+        { _canvas.drawCentreString(t, x, y); }
+
+    // ── Weather icon ──────────────────────────────────────────────────────────
+    void drawWeatherIcon(const char* cond, int16_t x, int16_t y, int16_t size) override
+        { drawWeatherIconOnCanvas(_canvas, cond, x, y, size); }
+
+    // ── E-ink partial refresh ─────────────────────────────────────────────────
+    // Sets a clip rect on M5.Display before pushing the full canvas so that the
+    // e-ink driver only cycles the pixels inside the widget's bounding box.
+    void flushBoundingBox(int16_t x, int16_t y, int16_t w, int16_t h) override {
+        M5.Display.setEpdMode(epd_mode_t::epd_fastest);
+        M5.Display.startWrite();
+        M5.Display.setClipRect(x, y, w, h);
+        _canvas.pushSprite(0, 0);
+        M5.Display.clearClipRect();
+        M5.Display.endWrite();
+    }
+
+    int16_t getWidth()  const override { return static_cast<int16_t>(_canvas.width()); }
+    int16_t getHeight() const override { return static_cast<int16_t>(_canvas.height()); }
+};
+
+#endif // M5_CANVAS_CONTROLLER_H

--- a/lib/Display/PageBase.h
+++ b/lib/Display/PageBase.h
@@ -1,0 +1,72 @@
+/**
+ * @file PageBase.h
+ * @brief Page engine base class for component-based screen layouts.
+ *
+ * PageBase owns a list of Widget pointers and drives the render loop:
+ *   1. Iterate all widgets.
+ *   2. Call draw() only on dirty entries.
+ *   3. After each dirty draw, call IDisplayController::flushBoundingBox() so
+ *      the e-ink panel performs a targeted epd_fastest partial refresh limited
+ *      to that widget's bounding rectangle.
+ *
+ * On a forced full refresh (forceFullRefresh = true) every widget is redrawn
+ * unconditionally and a single full-screen flush is issued at the end.
+ *
+ * Named PageBase to avoid a name collision with the existing Page enum in
+ * DisplayManager.h which selects the active interactive view.
+ *
+ * Ownership: PageBase owns its widget pointers and deletes them in its
+ * destructor.  Widgets should be allocated with new and added via addWidget().
+ */
+#ifndef PAGE_BASE_H
+#define PAGE_BASE_H
+
+#include "Widget.h"
+#include "IDisplayController.h"
+#include <vector>
+
+class PageBase {
+protected:
+    std::vector<Widget*> _widgets;
+    IDisplayController*  _gfx;
+
+public:
+    explicit PageBase(IDisplayController* gfx) : _gfx(gfx) {}
+
+    virtual ~PageBase() {
+        for (auto* w : _widgets) delete w;
+    }
+
+    void addWidget(Widget* w) {
+        _widgets.push_back(w);
+    }
+
+    /**
+     * @brief Render all dirty (or all, on force) widgets and flush to display.
+     *
+     * @param forceFullRefresh  When true every widget is redrawn regardless of
+     *                          its dirty flag, and a single full-canvas flush is
+     *                          issued at the end instead of per-widget flushes.
+     */
+    void render(bool forceFullRefresh = false) {
+        for (auto* w : _widgets) {
+            if (w->isDirty() || forceFullRefresh) {
+                w->draw();
+                if (!forceFullRefresh) {
+                    _gfx->flushBoundingBox(w->getX(), w->getY(),
+                                           w->getWidth(), w->getHeight());
+                }
+            }
+        }
+        if (forceFullRefresh) {
+            _gfx->flushBoundingBox(0, 0, _gfx->getWidth(), _gfx->getHeight());
+        }
+    }
+
+    // Mark every widget dirty — call before returning to this page from another.
+    void invalidateAll() {
+        for (auto* w : _widgets) w->markDirty();
+    }
+};
+
+#endif // PAGE_BASE_H

--- a/lib/Display/WeatherIconHelper.h
+++ b/lib/Display/WeatherIconHelper.h
@@ -1,0 +1,81 @@
+/**
+ * @file WeatherIconHelper.h
+ * @brief Shared weather-icon drawing function for DisplayManager and Widget impls.
+ *
+ * Extracted from DisplayManager::_drawWeatherIcon so that both the legacy
+ * rendering path and the new Widget / M5CanvasController path share one
+ * authoritative implementation, preventing the two copies from diverging.
+ *
+ * The template accepts any M5GFX canvas (M5Canvas, LGFX_Sprite) since the
+ * only canvas primitive used is drawPixel(), which is defined on LGFXBase.
+ */
+#ifndef WEATHER_ICON_HELPER_H
+#define WEATHER_ICON_HELPER_H
+
+#include "weather_bitmaps.h"
+#include <Arduino.h>
+
+/**
+ * @brief Draw a weather-condition icon onto any LGFX-compatible canvas.
+ *
+ * Selects the matching XBM bitmap from weather_bitmaps.h using the same
+ * condition-string rules as DisplayManager::_drawWeatherIcon, then scales
+ * the 32×32 source image to @p size × @p size pixels using nearest-neighbour
+ * scaling, centred on (@p x, @p y).
+ *
+ * @tparam Canvas  Any LGFX canvas type that provides drawPixel(x, y, color).
+ * @param canvas    Target canvas.
+ * @param condition Weather condition string (e.g. "Partly Cloudy").
+ * @param x         Centre X of the icon.
+ * @param y         Centre Y of the icon.
+ * @param size      Pixel side-length of the rendered icon.
+ */
+template <typename Canvas>
+void drawWeatherIconOnCanvas(Canvas& canvas, const char* condition, int x, int y, int size) {
+    String cond = condition;
+    cond.toLowerCase();
+
+    const uint8_t* bmp = icon_cloudy_bmp; // default fallback
+
+    if      (cond.indexOf("tornado")       >= 0)                                         bmp = icon_tornado_bmp;
+    else if (cond.indexOf("hurricane")     >= 0 || cond.indexOf("tropical storm") >= 0)  bmp = icon_hurricane_bmp;
+    else if (cond.indexOf("hail")          >= 0)                                         bmp = icon_hail_bmp;
+    else if (cond.indexOf("thunder")       >= 0 || cond.indexOf("t-storm") >= 0
+             || cond.indexOf("tstorm")     >= 0)                                         bmp = icon_thunder_bmp;
+    else if (cond.indexOf("freezing")      >= 0)                                         bmp = icon_freezing_rain_bmp;
+    else if (cond.indexOf("sleet")         >= 0 || cond.indexOf("mixed")   >= 0)         bmp = icon_sleet_bmp;
+    else if (cond.indexOf("blowing snow")  >= 0 || cond.indexOf("blizzard") >= 0)        bmp = icon_blowing_snow_bmp;
+    else if (cond.indexOf("heavy snow")    >= 0)                                         bmp = icon_heavy_snow_bmp;
+    else if (cond.indexOf("snow")          >= 0 || cond.indexOf("flurr")   >= 0)         bmp = icon_snow_bmp;
+    else if (cond.indexOf("heavy shower")  >= 0 || cond.indexOf("heavy rain") >= 0)      bmp = icon_heavy_showers_bmp;
+    else if (cond.indexOf("drizzle")       >= 0)                                         bmp = icon_drizzle_bmp;
+    else if (cond.indexOf("rain")          >= 0 || cond.indexOf("shower")  >= 0)         bmp = icon_rain_bmp;
+    else if (cond.indexOf("fog")           >= 0)                                         bmp = icon_foggy_bmp;
+    else if (cond.indexOf("haze")          >= 0 || cond.indexOf("mist")    >= 0)         bmp = icon_haze_bmp;
+    else if (cond.indexOf("smoke")         >= 0 || cond.indexOf("ash")     >= 0)         bmp = icon_smoky_bmp;
+    else if (cond.indexOf("dust")          >= 0 || cond.indexOf("sand")    >= 0)         bmp = icon_haze_bmp;
+    else if (cond.indexOf("blustery")      >= 0 || cond.indexOf("squall")  >= 0)         bmp = icon_blustery_bmp;
+    else if (cond.indexOf("wind")          >= 0 || cond.indexOf("breezy")  >= 0)         bmp = icon_windy_bmp;
+    else if (cond.indexOf("mostly cloudy") >= 0 || cond.indexOf("overcast") >= 0)        bmp = icon_mostly_cloudy_bmp;
+    else if (cond.indexOf("partly cloudy") >= 0 || cond.indexOf("partly sunny") >= 0)    bmp = icon_partly_cloudy_bmp;
+    else if (cond.indexOf("cloudy")        >= 0)                                         bmp = icon_cloudy_bmp;
+    else if (cond.indexOf("sun")           >= 0 || cond.indexOf("clear") >= 0
+             || cond.indexOf("fair")       >= 0)                                         bmp = icon_clear_bmp;
+    else if (cond.indexOf("n/a")           >= 0 || cond.indexOf("unknown") >= 0
+             || cond.length()             == 0)                                          bmp = icon_not_available_bmp;
+
+    static constexpr int SRC_W = 32, SRC_H = 32, BYTES_PER_ROW = 4;
+    int draw_x = x - size / 2;
+    int draw_y = y - size / 2;
+    for (int oy = 0; oy < size; oy++) {
+        int sy = oy * SRC_H / size;
+        for (int ox = 0; ox < size; ox++) {
+            int sx    = ox * SRC_W / size;
+            uint8_t b = pgm_read_byte(&bmp[sy * BYTES_PER_ROW + sx / 8]);
+            bool dark = (b >> (sx % 8)) & 1;
+            canvas.drawPixel(draw_x + ox, draw_y + oy, dark ? TFT_BLACK : TFT_WHITE);
+        }
+    }
+}
+
+#endif // WEATHER_ICON_HELPER_H

--- a/lib/Display/Widget.h
+++ b/lib/Display/Widget.h
@@ -1,0 +1,49 @@
+/**
+ * @file Widget.h
+ * @brief Abstract base class for all component-based UI elements.
+ *
+ * Every visual element on the display inherits from Widget.  The base class
+ * encapsulates:
+ *   - bounding-box geometry (_x, _y, _w, _h) used by PageBase::render() to
+ *     target e-ink partial refreshes at exactly the dirty region.
+ *   - dirty flag (_isDirty) so the Page engine only redraws elements whose
+ *     data actually changed since the last render cycle.
+ *   - a pointer to IDisplayController (_gfx) for hardware-agnostic drawing.
+ *
+ * Subclasses implement draw() using only IDisplayController primitives so
+ * that widget logic is fully decoupled from M5GFX / LGFX internals.
+ */
+#ifndef WIDGET_H
+#define WIDGET_H
+
+#include "IDisplayController.h"
+
+class Widget {
+protected:
+    int16_t  _x, _y;
+    uint16_t _w, _h;
+    bool     _isDirty = true;
+    IDisplayController* _gfx;
+
+public:
+    Widget(IDisplayController* gfx, int16_t x, int16_t y, uint16_t w, uint16_t h)
+        : _x(x), _y(y), _w(w), _h(h), _isDirty(true), _gfx(gfx) {}
+
+    virtual ~Widget() = default;
+
+    // Subclasses implement this to (re)draw their content via _gfx primitives.
+    // Implementations must call clearDirty() before returning.
+    virtual void draw() = 0;
+
+    bool isDirty()    const { return _isDirty; }
+    void markDirty()        { _isDirty = true; }
+    void clearDirty()       { _isDirty = false; }
+
+    // Bounding-box accessors used by PageBase for targeted partial refresh.
+    int16_t  getX()      const { return _x; }
+    int16_t  getY()      const { return _y; }
+    uint16_t getWidth()  const { return _w; }
+    uint16_t getHeight() const { return _h; }
+};
+
+#endif // WIDGET_H

--- a/lib/Display/Widgets/BatteryWidget.h
+++ b/lib/Display/Widgets/BatteryWidget.h
@@ -1,0 +1,98 @@
+/**
+ * @file BatteryWidget.h
+ * @brief Battery gauge widget — outline cell, fill bar, and percentage text.
+ *
+ * Marks dirty only when the level crosses a 5 % bucket boundary (or when the
+ * charging state changes), so normal ADC noise does not trigger unnecessary
+ * e-ink partial refreshes.
+ *
+ * Drawing geometry mirrors DisplayManager::_drawBattery() exactly so the two
+ * can be swapped without visual change.
+ *
+ * Default bounding box: top-right corner, 100 × 25 px.
+ */
+#ifndef BATTERY_WIDGET_H
+#define BATTERY_WIDGET_H
+
+#include "../Widget.h"
+#include <stdio.h>
+#include <algorithm>
+
+class BatteryWidget : public Widget {
+    int  _level    = -1;   // -1 forces first draw
+    bool _charging = false;
+
+    static int _bucket(int level) { return level / 5; }
+
+public:
+    BatteryWidget(IDisplayController* gfx,
+                  int16_t x, int16_t y,
+                  uint16_t w = 100, uint16_t h = 25)
+        : Widget(gfx, x, y, w, h) {}
+
+    /**
+     * @brief Feed updated battery state; marks dirty on 5 % bucket change or
+     *        charging state flip.
+     * @param level    Battery level 0–100 %.
+     * @param charging True when a USB supply is detected.
+     */
+    void update(int level, bool charging) {
+        if (_level < 0
+         || _bucket(level) != _bucket(_level)
+         || charging != _charging) {
+            _level    = level;
+            _charging = charging;
+            markDirty();
+        }
+    }
+
+    void draw() override {
+        _gfx->fillRect(_x, _y, _w, _h, TFT_WHITE);
+
+        int cellX = _x + _w - 44;
+        int cellY = _y + 3;
+
+        // Outer cell outline + positive terminal nub
+        _gfx->drawRoundRect(cellX, cellY, 40, 20, 3, TFT_BLACK);
+        _gfx->fillRect(cellX + 40, cellY + 5, 4, 10, TFT_BLACK);
+
+        if (_charging) {
+            // Bold '+' cross inside the cell
+            _gfx->fillRect(cellX + 17, cellY + 6,  6,  8, TFT_BLACK); // vertical
+            _gfx->fillRect(cellX + 14, cellY + 8, 12,  4, TFT_BLACK); // horizontal
+        } else {
+            int fillW = (36 * std::max(0, std::min(100, _level))) / 100;
+            if (fillW > 0) {
+                if (_level <= 15) {
+                    // Striped fill for critical level warning
+                    for (int col = 0; col < fillW; col++) {
+                        if ((col / 2) % 2 == 0)
+                            _gfx->fillRect(cellX + 2 + col, cellY + 2, 1, 16, TFT_BLACK);
+                    }
+                } else {
+                    _gfx->fillRect(cellX + 2, cellY + 2, fillW, 16, TFT_BLACK);
+                }
+            }
+        }
+
+        // Percentage text left of the cell
+        char buf[16];
+        if (_charging)
+            snprintf(buf, sizeof(buf), "+%d%%", _level);
+        else if (_level <= 15)
+            snprintf(buf, sizeof(buf), "%d%%!", _level);
+        else
+            snprintf(buf, sizeof(buf), "%d%%",  _level);
+
+        _gfx->setFont(WidgetFont::Tiny);
+        _gfx->setTextSize(1.0f);
+        _gfx->setTextColor(TFT_BLACK);
+        _gfx->setTextDatum(WidgetDatum::MiddleRight);
+        _gfx->drawString(buf, cellX - 5, cellY + 10);
+        _gfx->setTextDatum(WidgetDatum::TopLeft);
+
+        clearDirty();
+    }
+};
+
+#endif // BATTERY_WIDGET_H

--- a/lib/Display/Widgets/ClockWidget.h
+++ b/lib/Display/Widgets/ClockWidget.h
@@ -51,7 +51,7 @@ public:
 
         // Time string — large bold, centred in the widget
         _gfx->setFont(WidgetFont::XLargeBold);
-        _gfx->setTextSize(2.0f);
+        _gfx->setTextSize(1.5f);
         _gfx->setTextColor(TFT_BLACK);
         _gfx->setTextDatum(WidgetDatum::TopCenter);
         _gfx->drawString(timeBuf, _x + _w / 2, _y + 5);

--- a/lib/Display/Widgets/ClockWidget.h
+++ b/lib/Display/Widgets/ClockWidget.h
@@ -1,0 +1,72 @@
+/**
+ * @file ClockWidget.h
+ * @brief Clock strip widget — time + optional NTP-failure badge.
+ *
+ * Marks dirty only when tm_hour or tm_min changes, or when the NTP failure
+ * state flips, so the e-ink partial refresh fires at most once per minute
+ * rather than on every render tick.
+ *
+ * Default bounding box: full-width clock strip (x=0, y=0, w=540, h=95),
+ * matching the region used by DisplayManager::updateClockOnly().
+ */
+#ifndef CLOCK_WIDGET_H
+#define CLOCK_WIDGET_H
+
+#include "../Widget.h"
+#include <time.h>
+#include <stdio.h>
+#include <string.h>
+
+class ClockWidget : public Widget {
+    struct tm _time     = {};
+    bool      _ntpFailed = false;
+
+public:
+    ClockWidget(IDisplayController* gfx,
+                int16_t x, int16_t y, uint16_t w, uint16_t h)
+        : Widget(gfx, x, y, w, h) {}
+
+    /**
+     * @brief Feed updated time; marks dirty only when the displayed minute changes.
+     * @param t          Current local time.
+     * @param ntpFailed  When true a small "NTP!" badge is rendered next to the time.
+     */
+    void update(const struct tm& t, bool ntpFailed = false) {
+        if (_time.tm_hour  != t.tm_hour
+         || _time.tm_min   != t.tm_min
+         || _ntpFailed     != ntpFailed) {
+            _time      = t;
+            _ntpFailed = ntpFailed;
+            markDirty();
+        }
+    }
+
+    void draw() override {
+        // Erase bounding box before redraw to prevent ghost remnants on e-ink.
+        _gfx->fillRect(_x, _y, _w, _h, TFT_WHITE);
+
+        char timeBuf[32], dateBuf[48];
+        strftime(timeBuf, sizeof(timeBuf), "%l:%M %p", &_time);
+        strftime(dateBuf, sizeof(dateBuf),  "%A, %B %d %Y", &_time);
+
+        // Time string — large bold, centred in the widget
+        _gfx->setFont(WidgetFont::XLargeBold);
+        _gfx->setTextSize(2.0f);
+        _gfx->setTextColor(TFT_BLACK);
+        _gfx->setTextDatum(WidgetDatum::TopCenter);
+        _gfx->drawString(timeBuf, _x + _w / 2, _y + 5);
+
+        // NTP failure badge in top-right corner
+        if (_ntpFailed) {
+            _gfx->setFont(WidgetFont::Tiny);
+            _gfx->setTextSize(1.0f);
+            _gfx->setTextDatum(WidgetDatum::TopLeft);
+            _gfx->drawString("NTP!", _x + _w - 44, _y + 22);
+        }
+
+        _gfx->setTextDatum(WidgetDatum::TopLeft);
+        clearDirty();
+    }
+};
+
+#endif // CLOCK_WIDGET_H

--- a/lib/Display/Widgets/ForecastColumnWidget.h
+++ b/lib/Display/Widgets/ForecastColumnWidget.h
@@ -1,0 +1,156 @@
+/**
+ * @file ForecastColumnWidget.h
+ * @brief Single-day forecast column widget.
+ *
+ * Renders one vertical column of the 10-day forecast view:
+ *   - Day label (weekday + date, or "Today")
+ *   - Weather icon (52 px)
+ *   - Condition text (truncated at 12 chars)
+ *   - Precipitation-type badge (Rain / Snow / Storm / Ice / Hail)
+ *   - H / L temperature line
+ *   - Temperature range bar scaled to the 10-day global min/max span
+ *   - Precipitation chance
+ *
+ * globalMin / globalMax must be provided by the caller (the Page/Controller
+ * that owns the three ForecastColumnWidgets) so the range bars are comparable
+ * across columns on the same screen.
+ *
+ * Layout geometry matches drawPageForecast() so this widget is a drop-in
+ * replacement for the inline column-drawing loop.
+ */
+#ifndef FORECAST_COLUMN_WIDGET_H
+#define FORECAST_COLUMN_WIDGET_H
+
+#include "../Widget.h"
+#include <WeatherService.h>
+#include <time.h>
+#include <stdio.h>
+#include <string.h>
+#include <algorithm>
+
+class ForecastColumnWidget : public Widget {
+    DailyForecast _day    = {};
+    bool          _isToday = false;
+    float         _globalMin = 0.0f;
+    float         _globalMax = 1.0f;
+
+public:
+    ForecastColumnWidget(IDisplayController* gfx,
+                         int16_t x, int16_t y,
+                         uint16_t w, uint16_t h)
+        : Widget(gfx, x, y, w, h) {}
+
+    /**
+     * @brief Feed a new forecast day entry.
+     * @param day        Forecast data for this column's day.
+     * @param isToday    When true the day label reads "Today" instead of weekday.
+     * @param globalMin  10-day low temperature (for the range bar baseline).
+     * @param globalMax  10-day high temperature (for the range bar ceiling).
+     */
+    void update(const DailyForecast& day, bool isToday,
+                float globalMin, float globalMax) {
+        bool changed = (isToday            != _isToday)
+                    || (day.dayTime        != _day.dayTime)
+                    || (day.maxTempC       != _day.maxTempC)
+                    || (day.minTempC       != _day.minTempC)
+                    || (day.precipChance   != _day.precipChance)
+                    || (strncmp(day.condition, _day.condition,
+                                sizeof(_day.condition) - 1) != 0);
+        if (changed) {
+            _day       = day;
+            _isToday   = isToday;
+            _globalMin = globalMin;
+            _globalMax = (globalMax - globalMin < 1.0f) ? globalMin + 1.0f : globalMax;
+            markDirty();
+        }
+    }
+
+    void draw() override {
+        _gfx->fillRect(_x, _y, _w, _h, TFT_WHITE);
+
+        int cx = _x + _w / 2;
+        _gfx->setTextColor(TFT_BLACK);
+        _gfx->setTextDatum(WidgetDatum::TopCenter);
+
+        // ── Day label ────────────────────────────────────────────────────────
+        _gfx->setFont(WidgetFont::Medium);
+        _gfx->setTextSize(1.0f);
+        if (_isToday) {
+            _gfx->drawString("Today", cx, _y + 8);
+        } else if (_day.dayTime > 0) {
+            struct tm dayTm;
+            time_t dt = _day.dayTime;
+            localtime_r(&dt, &dayTm);
+            char dayBuf[12];
+            strftime(dayBuf, sizeof(dayBuf), "%a %d", &dayTm);
+            _gfx->drawString(dayBuf, cx, _y + 8);
+        } else {
+            _gfx->drawString("--", cx, _y + 8);
+        }
+
+        // ── Weather icon ─────────────────────────────────────────────────────
+        int iconY = _y + 58;
+        _gfx->drawWeatherIcon(_day.condition, cx, iconY, 52);
+
+        // ── Condition text (truncated) ────────────────────────────────────────
+        _gfx->setFont(WidgetFont::Small);
+        char condBuf[16];
+        size_t condLen = strlen(_day.condition);
+        if (condLen > 12) {
+            strncpy(condBuf, _day.condition, 10);
+            condBuf[10] = '.'; condBuf[11] = '.'; condBuf[12] = '\0';
+        } else {
+            strncpy(condBuf, _day.condition, sizeof(condBuf) - 1);
+            condBuf[sizeof(condBuf) - 1] = '\0';
+        }
+        _gfx->drawString(condBuf, cx, _y + 104);
+
+        // ── Precipitation-type badge ──────────────────────────────────────────
+        {
+            String condLower = _day.condition;
+            condLower.toLowerCase();
+            const char* badge = nullptr;
+            if      (condLower.indexOf("thunder") >= 0 || condLower.indexOf("storm") >= 0) badge = "Storm";
+            else if (condLower.indexOf("hail")    >= 0)                                     badge = "Hail";
+            else if (condLower.indexOf("freezing") >= 0 || condLower.indexOf("sleet") >= 0
+                     || condLower.indexOf("ice")  >= 0 || condLower.indexOf("pellet") >= 0) badge = "Ice";
+            else if (condLower.indexOf("snow")    >= 0 || condLower.indexOf("blizzard") >= 0) badge = "Snow";
+            else if (condLower.indexOf("rain")    >= 0 || condLower.indexOf("shower") >= 0
+                     || condLower.indexOf("drizzle") >= 0)                                  badge = "Rain";
+            if (badge) {
+                int badgeX = cx - 18;
+                int badgeY = _y + 122;
+                _gfx->fillRect(badgeX, badgeY, 36, 13, TFT_BLACK);
+                _gfx->setTextColor(TFT_WHITE);
+                _gfx->drawString(badge, cx, badgeY + 1);
+                _gfx->setTextColor(TFT_BLACK);
+            }
+        }
+
+        // ── H / L temperatures ────────────────────────────────────────────────
+        char tempBuf[24];
+        snprintf(tempBuf, sizeof(tempBuf), "H:%.0f  L:%.0f", _day.maxTempC, _day.minTempC);
+        _gfx->drawString(tempBuf, cx, _y + 138);
+
+        // ── Temperature range bar (relative to 10-day span) ───────────────────
+        constexpr int barW = 100, barH = 7;
+        int barX = cx - barW / 2;
+        int barY = _y + 158;
+        float range = _globalMax - _globalMin;
+        _gfx->drawRect(barX, barY, barW, barH, TFT_BLACK);
+        int fillStart = static_cast<int>((_day.minTempC - _globalMin) / range * barW);
+        int fillEnd   = static_cast<int>((_day.maxTempC - _globalMin) / range * barW);
+        int fillW     = std::max(4, fillEnd - fillStart);
+        _gfx->fillRect(barX + fillStart, barY, fillW, barH, TFT_BLACK);
+
+        // ── Precipitation chance ──────────────────────────────────────────────
+        char popBuf[16];
+        snprintf(popBuf, sizeof(popBuf), "Precip: %d%%", _day.precipChance);
+        _gfx->drawString(popBuf, cx, _y + 178);
+
+        _gfx->setTextDatum(WidgetDatum::TopLeft);
+        clearDirty();
+    }
+};
+
+#endif // FORECAST_COLUMN_WIDGET_H

--- a/lib/Display/Widgets/HourlyRowWidget.h
+++ b/lib/Display/Widgets/HourlyRowWidget.h
@@ -1,0 +1,117 @@
+/**
+ * @file HourlyRowWidget.h
+ * @brief Single hourly-forecast cell widget.
+ *
+ * Renders one cell of the 4 × 6 hourly grid used by showHourlyPage():
+ *   - 12-hour time string
+ *   - Weather icon (36 px) mapped from the WMO weather code
+ *   - Temperature in °C
+ *   - Precipitation chance (omitted when 0)
+ *   - Wind speed in km/h (omitted when ≤ 0.5)
+ *
+ * Marks dirty only when any data field changes, so scrolling or rotating to
+ * a different page and back causes a full redraw, but a static hourly grid
+ * does not re-render unchanged cells.
+ *
+ * The WMO → condition mapping matches the one in DisplayManager::showHourlyPage().
+ */
+#ifndef HOURLY_ROW_WIDGET_H
+#define HOURLY_ROW_WIDGET_H
+
+#include "../Widget.h"
+#include <WeatherService.h>
+#include <time.h>
+#include <stdio.h>
+#include <string.h>
+
+class HourlyRowWidget : public Widget {
+    HourlyForecast _hour = {};
+
+    static const char* _wmoToCondition(int code) {
+        if (code == 0)                    return "Clear";
+        if (code <= 3)                    return "Partly Cloudy";
+        if (code == 45 || code == 48)     return "Fog";
+        if (code == 51 || code == 53)     return "Drizzle";
+        if (code == 55)                   return "Drizzle";
+        if (code == 56 || code == 57)     return "Freezing Drizzle";
+        if (code == 61 || code == 63)     return "Rain";
+        if (code == 65)                   return "Heavy Showers";
+        if (code == 66 || code == 67)     return "Freezing Rain";
+        if (code == 71 || code == 73)     return "Snow";
+        if (code == 75)                   return "Heavy Snow";
+        if (code == 77)                   return "Snow";
+        if (code == 80 || code == 81)     return "Rain";
+        if (code == 82)                   return "Heavy Showers";
+        if (code == 85 || code == 86)     return "Snow Showers";
+        if (code == 95)                   return "Thunderstorms";
+        if (code == 96 || code == 99)     return "Thunderstorms";
+        return "Mostly Cloudy";
+    }
+
+public:
+    HourlyRowWidget(IDisplayController* gfx,
+                    int16_t x, int16_t y,
+                    uint16_t w, uint16_t h)
+        : Widget(gfx, x, y, w, h) {}
+
+    /**
+     * @brief Feed one HourlyForecast entry; marks dirty when any field changes.
+     */
+    void update(const HourlyForecast& hour) {
+        bool changed = (_hour.timestamp    != hour.timestamp)
+                    || (_hour.tempC        != hour.tempC)
+                    || (_hour.precipChance != hour.precipChance)
+                    || (_hour.windKph      != hour.windKph)
+                    || (_hour.weatherCode  != hour.weatherCode);
+        if (changed) {
+            _hour = hour;
+            markDirty();
+        }
+    }
+
+    void draw() override {
+        _gfx->fillRect(_x, _y, _w, _h, TFT_WHITE);
+
+        int cx = _x + _w / 2;
+
+        // ── Time (12-hour, leading space trimmed) ─────────────────────────────
+        struct tm* ti = localtime(&_hour.timestamp);
+        char timeBuf[16];
+        strftime(timeBuf, sizeof(timeBuf), "%l:%M%p", ti);
+        const char* trimmed = (timeBuf[0] == ' ') ? timeBuf + 1 : timeBuf;
+
+        _gfx->setFont(WidgetFont::Small);
+        _gfx->setTextSize(1.0f);
+        _gfx->setTextColor(TFT_BLACK);
+        _gfx->setTextDatum(WidgetDatum::TopCenter);
+        _gfx->drawString(trimmed, cx, _y);
+
+        // ── Weather icon ──────────────────────────────────────────────────────
+        const char* cond = _wmoToCondition(_hour.weatherCode);
+        _gfx->drawWeatherIcon(cond, cx, _y + 30, 36);
+
+        // ── Temperature ───────────────────────────────────────────────────────
+        char tempBuf[16];
+        snprintf(tempBuf, sizeof(tempBuf), "%.0f C", _hour.tempC);
+        _gfx->drawString(tempBuf, cx, _y + 55);
+
+        // ── Precipitation % (hidden when 0) ───────────────────────────────────
+        if (_hour.precipChance > 0) {
+            char popBuf[16];
+            snprintf(popBuf, sizeof(popBuf), "%d%%", _hour.precipChance);
+            _gfx->drawString(popBuf, cx, _y + 75);
+        }
+
+        // ── Wind speed (hidden when calm) ─────────────────────────────────────
+        if (_hour.windKph > 0.5f) {
+            char wBuf[16];
+            snprintf(wBuf, sizeof(wBuf), "%.0fkm/h", _hour.windKph);
+            _gfx->drawString(wBuf, cx, _y + 93);
+        }
+
+        _gfx->setTextDatum(WidgetDatum::TopLeft);
+        clearDirty();
+    }
+};
+
+#endif // HOURLY_ROW_WIDGET_H

--- a/lib/Display/Widgets/WeatherHeroWidget.h
+++ b/lib/Display/Widgets/WeatherHeroWidget.h
@@ -1,0 +1,86 @@
+/**
+ * @file WeatherHeroWidget.h
+ * @brief Current-conditions hero widget — icon, temperature, and condition string.
+ *
+ * Marks dirty whenever temperature or condition text changes.  Mirrors the
+ * hero section drawn by DisplayManager::drawPageDashboard() at Y ≈ 200–400.
+ */
+#ifndef WEATHER_HERO_WIDGET_H
+#define WEATHER_HERO_WIDGET_H
+
+#include "../Widget.h"
+#include <stdio.h>
+#include <string.h>
+
+class WeatherHeroWidget : public Widget {
+    float _tempC        = 0.0f;
+    float _feelsLikeC   = 0.0f;
+    char  _condition[64] = {};
+
+public:
+    /**
+     * @param gfx  Drawing backend.
+     * @param x,y  Top-left origin of the bounding box.
+     * @param w,h  Bounding-box dimensions; default matches the Dashboard hero
+     *             section (540 × 200 px, starting at Y = 200).
+     */
+    WeatherHeroWidget(IDisplayController* gfx,
+                      int16_t x, int16_t y,
+                      uint16_t w = 540, uint16_t h = 200)
+        : Widget(gfx, x, y, w, h) {}
+
+    /**
+     * @brief Feed updated current-conditions data.
+     * @param tempC      Current temperature in °C.
+     * @param feelsLikeC Apparent temperature in °C (displayed as "Feels: X C").
+     * @param condition  Sky-condition string (e.g. "Partly Cloudy").
+     */
+    void update(float tempC, float feelsLikeC, const char* condition) {
+        bool changed = (_tempC      != tempC)
+                    || (_feelsLikeC != feelsLikeC)
+                    || (strncmp(_condition, condition, sizeof(_condition) - 1) != 0);
+        if (changed) {
+            _tempC      = tempC;
+            _feelsLikeC = feelsLikeC;
+            strncpy(_condition, condition, sizeof(_condition) - 1);
+            _condition[sizeof(_condition) - 1] = '\0';
+            markDirty();
+        }
+    }
+
+    void draw() override {
+        _gfx->fillRect(_x, _y, _w, _h, TFT_WHITE);
+
+        // Weather icon — left third, vertically centred
+        int iconX = _x + _w / 4;
+        int iconY = _y + _h / 2;
+        _gfx->drawWeatherIcon(_condition, iconX, iconY, 80);
+
+        // Temperature — right of icon, aligned near top of icon
+        char tempBuf[32];
+        snprintf(tempBuf, sizeof(tempBuf), "%.1f C", _tempC);
+        _gfx->setFont(WidgetFont::XLargeBold);
+        _gfx->setTextSize(1.5f);
+        _gfx->setTextColor(TFT_BLACK);
+        _gfx->setTextDatum(WidgetDatum::TopLeft);
+        _gfx->drawString(tempBuf, _x + _w / 2, _y + _h / 2 - 30);
+
+        // Feels-like — smaller, just below temperature
+        char feelsBuf[32];
+        snprintf(feelsBuf, sizeof(feelsBuf), "Feels: %.1f C", _feelsLikeC);
+        _gfx->setFont(WidgetFont::Medium);
+        _gfx->setTextSize(1.0f);
+        _gfx->drawString(feelsBuf, _x + _w / 2, _y + _h / 2 + 10);
+
+        // Condition string — centred below icon + temp block
+        _gfx->setFont(WidgetFont::XLarge);
+        _gfx->setTextSize(1.0f);
+        _gfx->setTextDatum(WidgetDatum::TopCenter);
+        _gfx->drawString(_condition, _x + _w / 2, _y + _h - 45);
+
+        _gfx->setTextDatum(WidgetDatum::TopLeft);
+        clearDirty();
+    }
+};
+
+#endif // WEATHER_HERO_WIDGET_H

--- a/lib/Input/InputManager.cpp
+++ b/lib/Input/InputManager.cpp
@@ -62,10 +62,16 @@ void InputManager::_taskFn(void* param) {
             holding = false;
         }
 
-        self->_processTouchGestures();
+        // Touch/button processing (M5.update) is handled by pollInput() on the
+        // main loop to avoid I2C contention with RTC and other peripherals.
 
         vTaskDelay(pdMS_TO_TICKS(kPollMs));
     }
+}
+
+// ── Public poll — call once per main-loop tick ───────────────────────────────
+void InputManager::pollInput() {
+    _processTouchGestures();
 }
 
 bool InputManager::isProvisioningTriggered() const {

--- a/lib/Input/InputManager.h
+++ b/lib/Input/InputManager.h
@@ -56,6 +56,15 @@ public:
     void begin();
 
     /**
+     * @brief Process touch and button state for this loop tick.
+     *
+     * Must be called once per main-loop iteration (from the same task/core
+     * as all other I2C operations) so that M5.update() is never called from
+     * the background GPIO task, avoiding I2C bus contention.
+     */
+    void pollInput();
+
+    /**
      * @brief Check if the re-provisioning button was held long enough.
      * @return @c true if G38 has been held HIGH for ≥10 s since the last clear.
      */


### PR DESCRIPTION
## Summary

- Adds a widget base class and page engine for component-based UI architecture
- Moves touch/button polling to main loop to prevent I2C contention
- Normalizes clock text size to 1.5f across all display modes

## Changes
- `feat(display)`: add widget base class and page engine for component-based UI
- `fix(input)`: move touch/button polling to main loop to prevent I2C contention
- `fix(display)`: normalize clock text size to 1.5f across all display modes

Closes #26