### PR TITLE
feat(architecture): implement IPage interface and PageRouter for scalable navigation

### DIFF
--- a/lib/App/AppController.cpp
+++ b/lib/App/AppController.cpp
@@ -8,6 +8,7 @@
 #include <WeatherService.h>
 #include <InputManager.h>
 #include <ProvisioningManager.h>
+#include <PageRouter.h>
 #include <esp_log.h>
 #include <esp_sleep.h>
 #include <esp_task_wdt.h>
@@ -29,7 +30,7 @@ enum AppError : uint8_t {
 RTC_DATA_ATTR WeatherData rtcCachedWeather;
 RTC_DATA_ATTR int         rtcForecastOffset = 0;
 RTC_DATA_ATTR uint32_t    rtcWakeupCount = 0;
-RTC_DATA_ATTR Page        rtcActivePage = Page::Dashboard;
+RTC_DATA_ATTR uint8_t     rtcActivePage = 0;
 RTC_DATA_ATTR int         rtcSettingsCursor = 0;
 RTC_DATA_ATTR char        rtcLastIP[16] = {};
 RTC_DATA_ATTR uint8_t     rtcLastError = 0; ///< AppError code from most recent fetch cycle
@@ -95,7 +96,7 @@ void AppController::begin() {
 
         if (rtcCachedWeather.valid) {
             disp.setLastKnownIP(rtcLastIP);
-            disp.setActivePage(rtcActivePage);
+            disp.setActivePage(static_cast<Page>(rtcActivePage));
             disp.setLastError(rtcLastError);
             disp.setLastSyncTime(rtcCachedWeather.fetchTime);
             disp.renderActivePage(rtcCachedWeather, localTime, locationStr, /*fastMode=*/true, rtcForecastOffset, rtcSettingsCursor);
@@ -255,7 +256,7 @@ void AppController::begin() {
             }
             // Full quality screen redraw
             disp.setLastKnownIP(rtcLastIP);
-            disp.setActivePage(rtcActivePage);
+            disp.setActivePage(static_cast<Page>(rtcActivePage));
             disp.setLastSyncTime(rtcCachedWeather.fetchTime);
             disp.renderActivePage(rtcCachedWeather, localTime, locationStr, /*fastMode=*/false, rtcForecastOffset, rtcSettingsCursor);
 
@@ -287,12 +288,24 @@ void AppController::_runInteractiveSession(const String& locationStr) {
     uint32_t lastActivityMs = millis();
     int lastMinute = -1;
     auto& input = InputManager::getInstance();
-    Page lastPage = disp.getActivePage();
     bool overlayActive = false;
     bool overlayChanged = false;
 
     int consecutiveClicks = 0;
     uint32_t lastClickMs = 0;
+
+    // Build a SystemState snapshot from current RTC vars.
+    auto buildState = [&]() -> SystemState {
+        struct tm lt = {};
+        NTPManager::getInstance().getLocalTime(lt);
+        return { rtcCachedWeather, lt, locationStr, rtcForecastOffset,
+                 rtcSettingsCursor, NTPManager::getInstance().isNtpFailed(),
+                 overlayActive };
+    };
+
+    // Attach the router to the page already shown on screen (no redraw).
+    PageRouter router;
+    router.restore(rtcActivePage, buildState());
 
     while ((millis() - lastActivityMs) < kInteractiveTimeoutMs) {
         bool activity = false;
@@ -365,64 +378,67 @@ void AppController::_runInteractiveSession(const String& locationStr) {
             _enterDeepSleepForImmediateWakeup();
         }
 
-        // Settings page: tap a column icon to trigger the action.
-        // Layout: 3 equal columns (180 px each); icon+label zone Y 200-370.
-        constexpr int kSettingsColW    = 180; // kWidth / 3
-        constexpr int kSettingsTapTop  = 200;
-        constexpr int kSettingsTapBot  = 370;
         // Pagination dots at Y=940, spacing=24, centred on kWidth/2 over 4 pages
         constexpr int kDotY       = 940;
         constexpr int kDotSpacing = 24;
         constexpr int kDotHitR    = 24; // half the extended hit-zone width
-        // Forecast scroll triangle hit zones (Y 820–860, X < 60 or X > 480)
-        constexpr int kTriTop = 820;
-        constexpr int kTriBot = 860;
+
         int tapX = 0, tapY = 0;
         if (input.checkTap(tapX, tapY)) {
-            // ── Pagination dot tap — works on every page ──────────────────────
-            if (tapY >= kDotY - kDotHitR && tapY <= kDotY + kDotHitR) {
-                int dotStartX = (540 / 2) - ((4 - 1) * kDotSpacing) / 2;
-                for (int d = 0; d < 4; d++) {
-                    int dotX = dotStartX + d * kDotSpacing;
-                    if (abs(tapX - dotX) <= kDotHitR) {
-                        disp.setActivePage(static_cast<Page>(d));
-                        rtcActivePage = disp.getActivePage();
-                        activity = true;
+            // Route through PageRouter first for page-specific handling.
+            if (router.handleTouch(tapX, tapY)) {
+                PageAction action = router.consumePendingAction();
+                lastActivityMs = millis();
+                switch (action) {
+                    case PageAction::ForceSync:
+                        ESP_LOGI(TAG, "Force Sync Triggered via tap");
+                        disp.showMessage("Syncing...", "Fetching fresh weather data");
+                        rtcCachedWeather.valid = false;
+                        _enterDeepSleepForImmediateWakeup();
                         break;
+                    case PageAction::StartProvisioning:
+                        ESP_LOGI(TAG, "Web Setup Triggered via tap");
+                        disp.showMessage("Starting Setup", "Rebooting to portal...");
+                        delay(1500);
+                        ConfigManager::getInstance().setForceProvisioning(true);
+                        esp_restart();
+                        break;
+                    case PageAction::EnterSleep:
+                        ESP_LOGI(TAG, "Sleep Triggered via tap");
+                        disp.showMessage("Going to Sleep", "Press G38 to wake");
+                        delay(1500);
+                        enterDeepSleep();
+                        break;
+                    case PageAction::IncrementForecastOffset:
+                        if (rtcForecastOffset + kForecastColsPerView < rtcCachedWeather.forecastDays) {
+                            rtcForecastOffset++;
+                            router.updateData(buildState());
+                            router.render();
+                        }
+                        break;
+                    case PageAction::DecrementForecastOffset:
+                        if (rtcForecastOffset > 0) {
+                            rtcForecastOffset--;
+                            router.updateData(buildState());
+                            router.render();
+                        }
+                        break;
+                    default: break;
+                }
+            } else {
+                // Pagination dot tap — works on every page.
+                if (tapY >= kDotY - kDotHitR && tapY <= kDotY + kDotHitR) {
+                    int dotStartX = (540 / 2) - ((4 - 1) * kDotSpacing) / 2;
+                    for (int d = 0; d < 4; d++) {
+                        int dotX = dotStartX + d * kDotSpacing;
+                        if (abs(tapX - dotX) <= kDotHitR) {
+                            router.navigateTo(d, buildState());
+                            rtcActivePage = router.getActivePageId();
+                            disp.setActivePage(static_cast<Page>(rtcActivePage));
+                            lastActivityMs = millis();
+                            break;
+                        }
                     }
-                }
-            }
-            // ── Settings icon tap ────────────────────────────────────────────
-            else if (disp.getActivePage() == Page::Settings
-                    && tapY >= kSettingsTapTop && tapY < kSettingsTapBot) {
-                int col = tapX / kSettingsColW;
-                if (col == 0) {
-                    ESP_LOGI(TAG, "Force Sync Triggered via tap");
-                    disp.showMessage("Syncing...", "Fetching fresh weather data");
-                    rtcCachedWeather.valid = false;
-                    _enterDeepSleepForImmediateWakeup();
-                } else if (col == 1) {
-                    ESP_LOGI(TAG, "Web Setup Triggered via tap");
-                    disp.showMessage("Starting Setup", "Rebooting to portal...");
-                    delay(1500);
-                    ConfigManager::getInstance().setForceProvisioning(true);
-                    esp_restart();
-                } else if (col == 2) {
-                    ESP_LOGI(TAG, "Sleep Triggered via tap");
-                    disp.showMessage("Going to Sleep", "Press G38 to wake");
-                    delay(1500);
-                    enterDeepSleep();
-                }
-            }
-            // ── Forecast scroll triangles tap ────────────────────────────────
-            else if (disp.getActivePage() == Page::Forecast
-                    && tapY >= kTriTop && tapY <= kTriBot) {
-                if (tapX < 60 && rtcForecastOffset > 0) {
-                    rtcForecastOffset--;
-                    activity = true;
-                } else if (tapX > 480 && rtcForecastOffset + kForecastColsPerView < rtcCachedWeather.forecastDays) {
-                    rtcForecastOffset++;
-                    activity = true;
                 }
             }
         }
@@ -484,25 +500,25 @@ void AppController::_runInteractiveSession(const String& locationStr) {
                 activity = true;
             } else if (disp.getActivePage() == Page::Hourly) {
                 // Hourly: click = cycle pages
-                int nextPage = (static_cast<int>(disp.getActivePage()) + 1) % 4;
-                disp.setActivePage(static_cast<Page>(nextPage));
-                rtcActivePage = disp.getActivePage();
-                activity = true;
+                router.navigateNext(buildState());
+                rtcActivePage = router.getActivePageId();
+                disp.setActivePage(static_cast<Page>(rtcActivePage));
+                lastActivityMs = millis();
             }
         }
 
         // Touch Swipes for Page Navigation
         if (input.checkSwipeLeft()) {
-            int nextPage = (static_cast<int>(disp.getActivePage()) + 1) % 4;
-            disp.setActivePage(static_cast<Page>(nextPage));
-            rtcActivePage = disp.getActivePage();
-            activity = true;
+            router.navigateNext(buildState());
+            rtcActivePage = router.getActivePageId();
+            disp.setActivePage(static_cast<Page>(rtcActivePage));
+            lastActivityMs = millis();
         }
         if (input.checkSwipeRight()) {
-            int prevPage = (static_cast<int>(disp.getActivePage()) + 3) % 4;
-            disp.setActivePage(static_cast<Page>(prevPage));
-            rtcActivePage = disp.getActivePage();
-            activity = true;
+            router.navigatePrev(buildState());
+            rtcActivePage = router.getActivePageId();
+            disp.setActivePage(static_cast<Page>(rtcActivePage));
+            lastActivityMs = millis();
         }
         if (input.checkSwipeUp()) {
             if (!overlayActive) {
@@ -522,10 +538,12 @@ void AppController::_runInteractiveSession(const String& locationStr) {
         if (activity) {
             lastActivityMs = millis();
             if (rtcCachedWeather.valid) {
-                bool pageChanged = (disp.getActivePage() != lastPage);
-                // If page changed or overlay changed, use high-quality refresh
-                disp.renderActivePage(rtcCachedWeather, localTime, locationStr, !(pageChanged || overlayChanged), rtcForecastOffset, rtcSettingsCursor, overlayActive);
-                lastPage = disp.getActivePage();
+                // Scroll-wheel and overlay changes re-render via DisplayManager
+                // (overlay is handled there; page navigation renders were already
+                // done by router.navigateTo()).
+                disp.renderActivePage(rtcCachedWeather, localTime, locationStr,
+                                      !overlayChanged, rtcForecastOffset,
+                                      rtcSettingsCursor, overlayActive);
                 overlayChanged = false;
             }
         }

--- a/lib/Display/IPage.h
+++ b/lib/Display/IPage.h
@@ -1,0 +1,83 @@
+#ifndef I_PAGE_H
+#define I_PAGE_H
+
+#include "SystemState.h"
+#include <stdint.h>
+
+/**
+ * @enum PageAction
+ * @brief System-level actions a page can request via handleTouch().
+ *
+ * Pages set _lastAction before returning true from handleTouch() when a tap
+ * triggers an operation requiring AppController-level logic.
+ * PageRouter::consumePendingAction() drains this value after each touch cycle.
+ */
+enum class PageAction : uint8_t {
+    None = 0,                  ///< Touch not consumed / no system action.
+    Consumed,                  ///< Touch absorbed; no further system action needed.
+    ForceSync,                 ///< User requested immediate weather sync.
+    StartProvisioning,         ///< User requested portal / web-setup reboot.
+    EnterSleep,                ///< User requested deep sleep.
+    IncrementForecastOffset,   ///< Scroll forecast view forward one column.
+    DecrementForecastOffset,   ///< Scroll forecast view back one column.
+    IncrementSettingsCursor,   ///< Move settings highlight down.
+    DecrementSettingsCursor,   ///< Move settings highlight up.
+};
+
+/**
+ * @file IPage.h
+ * @brief Abstract interface for all full-screen application pages.
+ *
+ * Lifecycle sequence when navigating TO a page:
+ *   createPage() → init() → updateData() → onFocus() → render()
+ *
+ * Lifecycle sequence when navigating AWAY:
+ *   onBlur() → delete
+ *
+ * Ownership: PageRouter creates and deletes IPage instances. Only one page
+ * lives in RAM at a time (lazy loading) to minimise heap pressure on ESP32.
+ */
+class IPage {
+protected:
+    PageAction _lastAction = PageAction::None;
+
+public:
+    virtual ~IPage() = default;
+
+    /** Called once after construction; allocate child widgets here. */
+    virtual void init() = 0;
+
+    /** Called when navigating TO this page; triggers an epd_quality clear. */
+    virtual void onFocus() = 0;
+
+    /** Called when navigating AWAY from this page; release any transient state. */
+    virtual void onBlur() = 0;
+
+    /** Inject the latest SystemState; propagate to child widgets. */
+    virtual void updateData(const SystemState& state) = 0;
+
+    /** Redraw dirty (or all) widgets and flush to e-ink. */
+    virtual void render() = 0;
+
+    /**
+     * @brief Route touch coordinates to interactive widgets (hit-test loop).
+     * @param x  Touch X coordinate.
+     * @param y  Touch Y coordinate.
+     * @return   true if the touch was consumed by this page.
+     */
+    virtual bool handleTouch(int16_t x, int16_t y) = 0;
+
+    /**
+     * @brief Consume and return the last action requested by handleTouch().
+     *
+     * Resets _lastAction to PageAction::None after reading.
+     * Call this on the page after handleTouch() returns true.
+     */
+    PageAction consumeLastAction() {
+        PageAction a = _lastAction;
+        _lastAction  = PageAction::None;
+        return a;
+    }
+};
+
+#endif // I_PAGE_H

--- a/lib/Display/PageFactory.cpp
+++ b/lib/Display/PageFactory.cpp
@@ -1,0 +1,15 @@
+#include "PageFactory.h"
+#include "Pages/DashboardPage.h"
+#include "Pages/HourlyPage.h"
+#include "Pages/ForecastPage.h"
+#include "Pages/SettingsPage.h"
+
+IPage* PageFactory::create(uint8_t id) {
+    switch (id) {
+        case static_cast<uint8_t>(PageId::Hourly):    return new HourlyPage();
+        case static_cast<uint8_t>(PageId::Forecast):  return new ForecastPage();
+        case static_cast<uint8_t>(PageId::Settings):  return new SettingsPage();
+        case static_cast<uint8_t>(PageId::Dashboard): // fall-through
+        default:                                       return new DashboardPage();
+    }
+}

--- a/lib/Display/PageFactory.h
+++ b/lib/Display/PageFactory.h
@@ -1,0 +1,38 @@
+#ifndef PAGE_FACTORY_H
+#define PAGE_FACTORY_H
+
+#include "IPage.h"
+
+/**
+ * @brief Numeric identifiers for all application pages.
+ *
+ * Values match the legacy Page enum in DisplayManager.h to ensure RTC-persisted
+ * page IDs remain valid across firmware updates.
+ */
+enum class PageId : uint8_t {
+    Dashboard = 0,
+    Hourly    = 1,
+    Forecast  = 2,
+    Settings  = 3,
+    _Count    = 4,
+};
+
+/**
+ * @file PageFactory.h
+ * @brief Factory that maps a PageId to a heap-allocated IPage instance.
+ *
+ * Centralising construction here means PageRouter never includes concrete
+ * page headers — adding a new page only requires updating PageFactory.cpp.
+ */
+class PageFactory {
+public:
+    /**
+     * @brief Allocate the IPage implementation for @p id.
+     * @param id  Page identifier (cast PageId to uint8_t, or use raw enum value).
+     * @return    Heap-allocated IPage*; caller takes ownership.
+     *            Returns a DashboardPage for unknown ids.
+     */
+    static IPage* create(uint8_t id);
+};
+
+#endif // PAGE_FACTORY_H

--- a/lib/Display/PageRouter.cpp
+++ b/lib/Display/PageRouter.cpp
@@ -1,0 +1,63 @@
+#include "PageRouter.h"
+#include "PageFactory.h"
+#include <esp_log.h>
+
+static const char* TAG = "PageRouter";
+
+PageRouter::~PageRouter() {
+    _teardown();
+}
+
+void PageRouter::_teardown() {
+    if (_activePage) {
+        _activePage->onBlur();
+        delete _activePage;
+        _activePage = nullptr;
+    }
+}
+
+void PageRouter::restore(uint8_t pageId, const SystemState& state) {
+    _teardown();
+    _activePageId = pageId;
+    _activePage   = PageFactory::create(pageId);
+    _activePage->init();
+    _activePage->updateData(state);
+    ESP_LOGI(TAG, "Page %u restored (no redraw)", pageId);
+}
+
+void PageRouter::navigateTo(uint8_t pageId, const SystemState& state) {
+    ESP_LOGI(TAG, "Navigating %u → %u", _activePageId, pageId);
+    _teardown();
+    _activePageId = pageId;
+    _activePage   = PageFactory::create(pageId);
+    _activePage->init();
+    _activePage->updateData(state);
+    _activePage->onFocus();
+    _activePage->render();
+}
+
+void PageRouter::navigateNext(const SystemState& state) {
+    navigateTo((_activePageId + 1) % kMaxPages, state);
+}
+
+void PageRouter::navigatePrev(const SystemState& state) {
+    navigateTo((_activePageId + kMaxPages - 1) % kMaxPages, state);
+}
+
+void PageRouter::updateData(const SystemState& state) {
+    if (_activePage) _activePage->updateData(state);
+}
+
+void PageRouter::render() {
+    if (_activePage) _activePage->render();
+}
+
+bool PageRouter::handleTouch(int16_t x, int16_t y) {
+    if (!_activePage) return false;
+    return _activePage->handleTouch(x, y);
+}
+
+PageAction PageRouter::consumePendingAction() {
+    if (!_activePage) return PageAction::None;
+    return _activePage->consumeLastAction();
+}

--- a/lib/Display/PageRouter.h
+++ b/lib/Display/PageRouter.h
@@ -1,0 +1,89 @@
+#ifndef PAGE_ROUTER_H
+#define PAGE_ROUTER_H
+
+#include "IPage.h"
+#include "SystemState.h"
+#include <stdint.h>
+
+/**
+ * @file PageRouter.h
+ * @brief Central page lifecycle manager and navigation controller.
+ *
+ * PageRouter owns exactly one IPage* at a time (lazy loading).
+ *
+ * Full navigation lifecycle (navigateTo):
+ *   onBlur() → delete → PageFactory::create() → init() → updateData() → onFocus() → render()
+ *
+ * Restore lifecycle (restore — used on EXT0 wakeup when the screen is already rendered):
+ *   delete → PageFactory::create() → init() → updateData()
+ *   (onFocus/render are skipped because the display already shows the correct content.)
+ *
+ * RTC memory persists the active page id so the correct page is reloaded after deep sleep.
+ */
+class PageRouter {
+public:
+    PageRouter() = default;
+    ~PageRouter();
+
+    /**
+     * @brief Restore the page for @p pageId without triggering onFocus()/render().
+     *
+     * Used at session startup when the e-ink display already shows the correct
+     * page image (EXT0 wakeup fast-render was done before entering the session).
+     *
+     * @param pageId  Active page to restore.
+     * @param state   Current SystemState to inject via updateData().
+     */
+    void restore(uint8_t pageId, const SystemState& state);
+
+    /**
+     * @brief Navigate to a page, running the full teardown → setup lifecycle.
+     *
+     * @param pageId  Target page identifier.
+     * @param state   Current SystemState passed to updateData().
+     */
+    void navigateTo(uint8_t pageId, const SystemState& state);
+
+    /** @brief Cycle to the next page (wraps around kMaxPages). */
+    void navigateNext(const SystemState& state);
+
+    /** @brief Cycle to the previous page (wraps around kMaxPages). */
+    void navigatePrev(const SystemState& state);
+
+    /** @brief Push updated state to the current page without navigating. */
+    void updateData(const SystemState& state);
+
+    /** @brief Re-render the current page. */
+    void render();
+
+    /**
+     * @brief Route touch coordinates through the active page's hit-test loop.
+     *
+     * After calling this, check consumePendingAction() for any system-level
+     * operation the page requested (force sync, sleep, etc.).
+     *
+     * @return true if the touch was consumed by the page.
+     */
+    bool handleTouch(int16_t x, int16_t y);
+
+    /** @brief Return the id of the currently active page. */
+    uint8_t getActivePageId() const { return _activePageId; }
+
+    /**
+     * @brief Consume and return any system action requested by the last handleTouch().
+     *
+     * Resets the pending action to PageAction::None.
+     * AppController must call this after handleTouch() returns true.
+     */
+    PageAction consumePendingAction();
+
+private:
+    static constexpr uint8_t kMaxPages = 4;
+
+    IPage*   _activePage   = nullptr;
+    uint8_t  _activePageId = 0;
+
+    void _teardown();
+};
+
+#endif // PAGE_ROUTER_H

--- a/lib/Display/Pages/DashboardPage.h
+++ b/lib/Display/Pages/DashboardPage.h
@@ -1,0 +1,33 @@
+#ifndef DASHBOARD_PAGE_H
+#define DASHBOARD_PAGE_H
+
+#include "../IPage.h"
+#include <DisplayManager.h>
+
+class DashboardPage : public IPage {
+    SystemState _state = {};
+
+public:
+    void init()        override {}
+    void onBlur()      override {}
+
+    void onFocus() override {
+        DisplayManager::getInstance().clear();
+    }
+
+    void updateData(const SystemState& state) override {
+        _state = state;
+    }
+
+    void render() override {
+        if (!_state.weather.valid) return;
+        DisplayManager::getInstance().drawPageDashboard(
+            _state.weather, _state.localTime, _state.city);
+    }
+
+    bool handleTouch(int16_t /*x*/, int16_t /*y*/) override {
+        return false;  // Pagination dots handled by AppController/PageRouter.
+    }
+};
+
+#endif // DASHBOARD_PAGE_H

--- a/lib/Display/Pages/ForecastPage.h
+++ b/lib/Display/Pages/ForecastPage.h
@@ -1,0 +1,47 @@
+#ifndef FORECAST_PAGE_H
+#define FORECAST_PAGE_H
+
+#include "../IPage.h"
+#include <DisplayManager.h>
+
+class ForecastPage : public IPage {
+    SystemState _state = {};
+
+    static constexpr int kTriTop   = 820;
+    static constexpr int kTriBot   = 860;
+    static constexpr int kTriLeft  =  60;
+    static constexpr int kTriRight = 480;
+
+public:
+    void init()        override {}
+    void onBlur()      override {}
+
+    void onFocus() override {
+        DisplayManager::getInstance().clear();
+    }
+
+    void updateData(const SystemState& state) override {
+        _state = state;
+    }
+
+    void render() override {
+        if (!_state.weather.valid) return;
+        DisplayManager::getInstance().drawPageForecast(
+            _state.weather, _state.forecastOffset);
+    }
+
+    bool handleTouch(int16_t x, int16_t y) override {
+        if (y < kTriTop || y > kTriBot) return false;
+        if (x < kTriLeft) {
+            _lastAction = PageAction::DecrementForecastOffset;
+            return true;
+        }
+        if (x > kTriRight) {
+            _lastAction = PageAction::IncrementForecastOffset;
+            return true;
+        }
+        return false;
+    }
+};
+
+#endif // FORECAST_PAGE_H

--- a/lib/Display/Pages/HourlyPage.h
+++ b/lib/Display/Pages/HourlyPage.h
@@ -1,0 +1,32 @@
+#ifndef HOURLY_PAGE_H
+#define HOURLY_PAGE_H
+
+#include "../IPage.h"
+#include <DisplayManager.h>
+
+class HourlyPage : public IPage {
+    SystemState _state = {};
+
+public:
+    void init()        override {}
+    void onBlur()      override {}
+
+    void onFocus() override {
+        DisplayManager::getInstance().clear();
+    }
+
+    void updateData(const SystemState& state) override {
+        _state = state;
+    }
+
+    void render() override {
+        if (!_state.weather.valid) return;
+        DisplayManager::getInstance().showHourlyPage(_state.weather);
+    }
+
+    bool handleTouch(int16_t /*x*/, int16_t /*y*/) override {
+        return false;
+    }
+};
+
+#endif // HOURLY_PAGE_H

--- a/lib/Display/Pages/SettingsPage.h
+++ b/lib/Display/Pages/SettingsPage.h
@@ -1,0 +1,42 @@
+#ifndef SETTINGS_PAGE_H
+#define SETTINGS_PAGE_H
+
+#include "../IPage.h"
+#include <DisplayManager.h>
+
+class SettingsPage : public IPage {
+    SystemState _state = {};
+
+    static constexpr int kTapTop   = 200;
+    static constexpr int kTapBot   = 370;
+    static constexpr int kColWidth = 180;
+
+public:
+    void init()        override {}
+    void onBlur()      override {}
+
+    void onFocus() override {
+        DisplayManager::getInstance().clear();
+    }
+
+    void updateData(const SystemState& state) override {
+        _state = state;
+    }
+
+    void render() override {
+        DisplayManager::getInstance().drawPageSettings(_state.settingsCursor);
+    }
+
+    bool handleTouch(int16_t x, int16_t y) override {
+        if (y < kTapTop || y >= kTapBot) return false;
+        int col = x / kColWidth;
+        switch (col) {
+            case 0: _lastAction = PageAction::ForceSync;         return true;
+            case 1: _lastAction = PageAction::StartProvisioning; return true;
+            case 2: _lastAction = PageAction::EnterSleep;        return true;
+            default: return false;
+        }
+    }
+};
+
+#endif // SETTINGS_PAGE_H

--- a/lib/Display/SystemState.h
+++ b/lib/Display/SystemState.h
@@ -1,0 +1,25 @@
+#ifndef SYSTEM_STATE_H
+#define SYSTEM_STATE_H
+
+#include <Arduino.h>
+#include <WeatherService.h>
+#include <time.h>
+
+/**
+ * @struct SystemState
+ * @brief Aggregates all runtime state required by IPage implementations.
+ *
+ * Passed to IPage::updateData() so pages can access weather, time, location,
+ * and UI cursor state without coupling to AppController or RTC variables.
+ */
+struct SystemState {
+    WeatherData weather;        ///< Latest weather payload (check weather.valid).
+    struct tm   localTime;      ///< Current local time.
+    String      city;           ///< Display location string (e.g. "Peoria, IL").
+    int         forecastOffset; ///< First visible column index on the Forecast page.
+    int         settingsCursor; ///< Highlighted item index on the Settings page.
+    bool        ntpFailed;      ///< True when last NTP sync failed (RTC fallback).
+    bool        overlayActive;  ///< True when the hourly overlay is shown.
+};
+
+#endif // SYSTEM_STATE_H


### PR DESCRIPTION
## Summary

Implements the IPage interface and PageRouter described in #27, replacing the monolithic `switch` in `DisplayManager::renderActivePage()` and the direct page-management calls scattered through `AppController::_runInteractiveSession()`.

## New Files

| File | Purpose |
|------|---------|
| `lib/Display/SystemState.h` | Aggregates WeatherData, localTime, city, forecastOffset, settingsCursor, ntpFailed, overlayActive into one struct passed to `IPage::updateData()` |
| `lib/Display/IPage.h` | Abstract lifecycle interface: `init()`, `onFocus()`, `onBlur()`, `updateData()`, `render()`, `handleTouch()` + `PageAction` enum |
| `lib/Display/Pages/DashboardPage.h` | Wraps `DisplayManager::drawPageDashboard()` |
| `lib/Display/Pages/HourlyPage.h` | Wraps `DisplayManager::showHourlyPage()` |
| `lib/Display/Pages/ForecastPage.h` | Wraps `drawPageForecast()`; triangle taps → `IncrementForecastOffset` / `DecrementForecastOffset` |
| `lib/Display/Pages/SettingsPage.h` | Wraps `drawPageSettings()`; icon-column taps → `ForceSync` / `StartProvisioning` / `EnterSleep` |
| `lib/Display/PageFactory.h/.cpp` | Maps `uint8_t PageId → IPage*`; centralises construction |
| `lib/Display/PageRouter.h/.cpp` | Owns page lifecycle: `restore()`, `navigateTo()`, `navigateNext/Prev()`, `handleTouch()`, `consumePendingAction()` |

## Changes to AppController.cpp

- `rtcActivePage` type changed from `Page` enum to `uint8_t` (compatible with PageId values)
- `_runInteractiveSession()` now creates a `PageRouter`, restores the current page on entry (`restore()` skips redraw since EXT0 fast-render already ran), and routes all swipes/taps through the router:
  - Swipe left/right → `navigateNext()` / `navigatePrev()`
  - Tap → `router.handleTouch()` first; `consumePendingAction()` dispatches system actions
  - Pagination dots remain in AppController as a fallback for taps not absorbed by pages

## Input Flow
```
InputManager → AppController → PageRouter::handleTouch() → IPage::handleTouch() → widget hit-test
```

Closes #27