### PR TITLE
feat(architecture): introduce EventBus for decoupled cross-module communication

### DIFF
--- a/lib/Core/EventBus.cpp
+++ b/lib/Core/EventBus.cpp
@@ -1,0 +1,22 @@
+#include "EventBus.h"
+
+EventBus::Table& EventBus::_table() {
+    static Table t;
+    return t;
+}
+
+void EventBus::subscribe(SystemEvent ev, Handler handler) {
+    _table()[static_cast<size_t>(ev)].push_back(std::move(handler));
+}
+
+void EventBus::publish(SystemEvent ev, void* payload) {
+    for (auto& h : _table()[static_cast<size_t>(ev)]) {
+        h(payload);
+    }
+}
+
+void EventBus::reset() {
+    for (auto& v : _table()) {
+        v.clear();
+    }
+}

--- a/lib/Core/EventBus.h
+++ b/lib/Core/EventBus.h
@@ -1,0 +1,76 @@
+/**
+ * @file EventBus.h
+ * @brief Minimal synchronous publish/subscribe event bus.
+ *
+ * EventBus decouples modules by letting publishers fire events without
+ * knowing which (if any) modules are listening.  All handlers execute
+ * synchronously in registration order inside publish(), so no RTOS
+ * primitives or extra stacks are required.
+ *
+ * **Thread safety:** subscribe() and reset() must be called from the
+ * initialisation context before any tasks are running.  publish() may be
+ * called from any single task, but concurrent publish() calls from multiple
+ * tasks are not safe without external locking.
+ *
+ * Example:
+ * @code
+ *   // Subscriber (called once at startup):
+ *   EventBus::subscribe(SystemEvent::EV_WEATHER_UPDATED, [](void* p) {
+ *       auto* data = static_cast<const WeatherData*>(p);
+ *       DisplayManager::getInstance().refresh(*data);
+ *   });
+ *
+ *   // Publisher:
+ *   EventBus::publish(SystemEvent::EV_WEATHER_UPDATED, &weatherData);
+ * @endcode
+ */
+#ifndef CORE_EVENT_BUS_H
+#define CORE_EVENT_BUS_H
+#include <functional>
+#include <array>
+#include <vector>
+#include "SystemEvents.h"
+
+class EventBus {
+public:
+    /** @brief Callback type: receives the raw payload pointer. */
+    using Handler = std::function<void(void*)>;
+
+    /**
+     * @brief Register a handler for a specific event.
+     *
+     * @param ev       Event type to subscribe to.
+     * @param handler  Callable invoked with the payload pointer on each publish.
+     *                 The handler is stored by value (captures are allowed).
+     */
+    static void subscribe(SystemEvent ev, Handler handler);
+
+    /**
+     * @brief Dispatch an event to all registered handlers synchronously.
+     *
+     * All handlers registered for @p ev are called in registration order.
+     * publish() returns only after every handler has completed.
+     *
+     * @param ev       Event to dispatch.
+     * @param payload  Optional pointer to event-specific data.  Cast to the
+     *                 appropriate payload type documented in SystemEvents.h.
+     *                 The payload must remain valid for the duration of the call.
+     */
+    static void publish(SystemEvent ev, void* payload = nullptr);
+
+    /**
+     * @brief Clear all subscriptions.
+     *
+     * Intended for unit tests that need a fresh EventBus state between runs.
+     */
+    static void reset();
+
+private:
+    using Table = std::array<std::vector<Handler>,
+                             static_cast<size_t>(SystemEvent::_COUNT)>;
+
+    /** @brief Returns the singleton dispatch table. */
+    static Table& _table();
+};
+
+#endif // CORE_EVENT_BUS_H

--- a/lib/Core/SystemEvents.h
+++ b/lib/Core/SystemEvents.h
@@ -1,0 +1,50 @@
+/**
+ * @file SystemEvents.h
+ * @brief Typed event identifiers and payload structs for the EventBus.
+ *
+ * Every event that crosses a module boundary must be listed here.  Payload
+ * ownership rules: the *publisher* owns the payload and it must remain valid
+ * for the entire (synchronous) duration of EventBus::publish().
+ */
+#ifndef CORE_SYSTEM_EVENTS_H
+#define CORE_SYSTEM_EVENTS_H
+#include <Arduino.h>
+
+// Forward declarations — include the relevant header before dereferencing.
+struct WeatherData;
+
+/**
+ * @enum SystemEvent
+ * @brief Enumeration of all application-wide events.
+ *
+ * _COUNT is a sentinel used to size the EventBus dispatch table.
+ * It must always be the last entry.
+ */
+enum class SystemEvent : uint8_t {
+    EV_WIFI_CONNECTED,        ///< WiFi association succeeded.      Payload: nullptr
+    EV_WIFI_DISCONNECTED,     ///< WiFi link dropped.               Payload: nullptr
+    EV_WEATHER_UPDATED,       ///< Fresh WeatherData available.      Payload: const WeatherData*
+    EV_BATTERY_LOW,           ///< Battery below warning threshold.  Payload: nullptr
+    EV_TOUCH_SWIPE_LEFT,      ///< Left-swipe gesture detected.      Payload: nullptr
+    EV_TOUCH_SWIPE_RIGHT,     ///< Right-swipe gesture detected.     Payload: nullptr
+    EV_TOUCH_SWIPE_UP,        ///< Up-swipe gesture detected.        Payload: nullptr
+    EV_TOUCH_SWIPE_DOWN,      ///< Down-swipe gesture detected.      Payload: nullptr
+    EV_PIN_PROMPT_REQUESTED,  ///< Module needs PIN from the user.   Payload: PinPromptPayload*
+    _COUNT                    ///< Sentinel — always keep last.
+};
+
+/**
+ * @struct PinPromptPayload
+ * @brief Payload for EV_PIN_PROMPT_REQUESTED.
+ *
+ * The publisher fills @c message and leaves @c result empty.  The subscriber
+ * (DisplayManager) calls promptPIN() synchronously and writes the entered PIN
+ * string into @c result before returning.  Because EventBus dispatch is
+ * synchronous, the publisher can read @c result immediately after publish().
+ */
+struct PinPromptPayload {
+    const char* message; ///< Prompt text; must be valid during the publish() call.
+    String      result;  ///< Filled by the DisplayManager subscriber.
+};
+
+#endif // CORE_SYSTEM_EVENTS_H

--- a/lib/Display/DisplayManager.cpp
+++ b/lib/Display/DisplayManager.cpp
@@ -1,6 +1,7 @@
 #include "DisplayManager.h"
 #include "WeatherIconHelper.h"
 #include "weather_bitmaps.h"
+#include <EventBus.h>
 #include <WiFi.h>
 #include <qrcode.h>
 #include <esp_log.h>
@@ -21,6 +22,14 @@ void DisplayManager::begin() {
     M5.Display.setTextColor(TFT_BLACK); // Transparent background
     _canvas.setColorDepth(1); // 1-bit footprint (B/W) pushes to DMA 4x faster!
     _canvas.createSprite(kWidth, kHeight);
+
+    // Subscribe to PIN prompt requests from InputManager (or any other module).
+    // The handler is called synchronously inside EventBus::publish(), so
+    // promptPIN()'s return value is available to the publisher immediately.
+    EventBus::subscribe(SystemEvent::EV_PIN_PROMPT_REQUESTED, [](void* p) {
+        auto* payload   = static_cast<PinPromptPayload*>(p);
+        payload->result = DisplayManager::getInstance().promptPIN(payload->message);
+    });
 }
 
 void DisplayManager::clear() {

--- a/lib/Input/InputManager.cpp
+++ b/lib/Input/InputManager.cpp
@@ -1,5 +1,5 @@
 #include "InputManager.h"
-#include <DisplayManager.h>
+#include <EventBus.h>
 #include <mbedtls/sha256.h>
 #include <esp_log.h>
 
@@ -198,7 +198,9 @@ void InputManager::_processTouchGestures() {
 
 // ── PIN entry ─────────────────────────────────────────────────────────────────
 String InputManager::waitForPIN(const String& message) {
-    return DisplayManager::getInstance().promptPIN(message);
+    PinPromptPayload payload{ message.c_str(), "" };
+    EventBus::publish(SystemEvent::EV_PIN_PROMPT_REQUESTED, &payload);
+    return payload.result;
 }
 
 // ── PIN verification ──────────────────────────────────────────────────────────

--- a/lib/Input/InputManager.cpp
+++ b/lib/Input/InputManager.cpp
@@ -1,4 +1,5 @@
 #include "InputManager.h"
+#include <M5Unified.h>
 #include <EventBus.h>
 #include <mbedtls/sha256.h>
 #include <esp_log.h>

--- a/lib/Network/WeatherService.cpp
+++ b/lib/Network/WeatherService.cpp
@@ -1,4 +1,5 @@
 #include "WeatherService.h"
+#include <EventBus.h>
 #include <HTTPClient.h>
 #include <WiFiClientSecure.h>
 #include <ArduinoJson.h>
@@ -311,6 +312,9 @@ WeatherData WeatherService::fetch(const String& lat, const String& lon,
         ESP_LOGI(TAG, "Weather: %s  %.1f°C  hum=%d%%  aqi=%d  sunrise=%ld  alert=%d",
                  data.condition, data.tempC, data.humidity, data.aqi, (long)data.sunriseTime,
                  (int)data.hasAlert);
+        // Notify subscribers (e.g. future cache or analytics modules) without
+        // coupling WeatherService to any display or storage code.
+        EventBus::publish(SystemEvent::EV_WEATHER_UPDATED, &data);
     } else {
         ESP_LOGW(TAG, "Current conditions fetch failed; supplemental data fetched but data.valid remains false");
     }


### PR DESCRIPTION
## Summary

Closes #30

Implements a minimal synchronous pub/sub `EventBus` in `lib/Core/` and performs the first two module-boundary migrations from the issue.

## New files

| File | Purpose |
|------|---------|
| `lib/Core/SystemEvents.h` | `SystemEvent` enum (9 events + `_COUNT` sentinel) and `PinPromptPayload` struct |
| `lib/Core/EventBus.h` | `EventBus` class: `subscribe()`, `publish()`, `reset()` |
| `lib/Core/EventBus.cpp` | Dispatch table implementation |

## Design

- **Synchronous dispatch**: all handlers run inside `publish()` before it returns — no RTOS queues or extra stacks needed.
- **Type-safe payload convention**: each event's payload type is documented in `SystemEvents.h` via doc comments; cast inside the handler.
- **Zero overhead when no subscribers**: the dispatch loop is a no-op over an empty vector.

## Migrations

### 1. `InputManager → DisplayManager` via `EV_PIN_PROMPT_REQUESTED`

**Before:** `InputManager.cpp` imported `<DisplayManager.h>` and called `DisplayManager::getInstance().promptPIN()` directly.

**After:** `InputManager` publishes `EV_PIN_PROMPT_REQUESTED` with a `PinPromptPayload`. `DisplayManager::begin()` subscribes and synchronously fills `payload->result`. The cross-module `#include` is gone; behaviour is unchanged.

### 2. `WeatherService` publishes `EV_WEATHER_UPDATED`

`WeatherService::fetch()` now calls `EventBus::publish(EV_WEATHER_UPDATED, &data)` after a successful fetch. `AppController` continues to consume the return value in this PR, but the event is live for subscribers in future migrations.

## Migration path (follow-up PRs)

Per the issue's recommended approach, the next steps are:
- Subscribe `AppController`/`DisplayManager` to `EV_WEATHER_UPDATED` and remove the direct call chain
- Publish `EV_WIFI_CONNECTED` / `EV_WIFI_DISCONNECTED` from `WiFiManager`
- Publish `EV_BATTERY_LOW` from the battery sampling path in `AppController`